### PR TITLE
Update pull request with $EDITOR

### DIFF
--- a/lib/octopolo.rb
+++ b/lib/octopolo.rb
@@ -12,4 +12,8 @@ module Octopolo
     @config ||= Octopolo::Config.parse
   end
 
+  def self.user_config
+    @user_config ||= Octopolo::UserConfig.parse
+  end
+
 end

--- a/lib/octopolo/commands/pull_request.rb
+++ b/lib/octopolo/commands/pull_request.rb
@@ -1,12 +1,13 @@
 desc "Create a pull request from the current branch to the application's designated deploy branch."
 command 'pull-request' do |c|
   config = Octopolo::Config.parse
+  user_config = Octopolo::UserConfig.parse
 
   c.desc "Branch to create the pull request against"
   c.flag [:d, :dest, :destination], :arg_name => "destination_branch", :default_value => config.deploy_branch
 
   c.desc "Use $EDITOR to update PR description before creating"
-  c.switch [:e, :editor], :default_value => false
+  c.switch [:e, :editor], :default_value => user_config.editor
 
   c.action do |global_options, options, args|
     require_relative '../scripts/pull_request'

--- a/lib/octopolo/commands/pull_request.rb
+++ b/lib/octopolo/commands/pull_request.rb
@@ -5,9 +5,12 @@ command 'pull-request' do |c|
   c.desc "Branch to create the pull request against"
   c.flag [:d, :dest, :destination], :arg_name => "destination_branch", :default_value => config.deploy_branch
 
+  c.desc "Use $EDITOR to update PR description before creating"
+  c.switch [:e, :editor], :default_value => false
+
   c.action do |global_options, options, args|
     require_relative '../scripts/pull_request'
     options = global_options.merge(options)
-    Octopolo::Scripts::PullRequest.execute options[:destination]
+    Octopolo::Scripts::PullRequest.execute options[:destination], options
   end
 end

--- a/lib/octopolo/github/pull_request_creator.rb
+++ b/lib/octopolo/github/pull_request_creator.rb
@@ -108,7 +108,9 @@ module Octopolo
       #
       # Returns a String
       def body
-        Renderer.render Renderer::PULL_REQUEST_BODY, body_locals
+        output = Renderer.render Renderer::PULL_REQUEST_BODY, body_locals
+        output = edit_body(output) if options[:editor]
+        output
       end
 
       def edit_body(body)

--- a/lib/octopolo/github/pull_request_creator.rb
+++ b/lib/octopolo/github/pull_request_creator.rb
@@ -1,4 +1,5 @@
 require_relative "../renderer"
+require 'tempfile'
 
 module Octopolo
   module GitHub
@@ -108,6 +109,15 @@ module Octopolo
       # Returns a String
       def body
         Renderer.render Renderer::PULL_REQUEST_BODY, body_locals
+      end
+
+      def edit_body(body)
+        return body unless ENV['EDITOR']
+        tempfile = Tempfile.new('octopolo_pull_request')
+        Octopolo::CLI.perform("#{ENV['EDITOR']} #{tempfile.path}")
+        output = tempfile.read
+        tempfile.unlink
+        output
       end
 
       # Public: The local variables to pass into the template

--- a/lib/octopolo/github/pull_request_creator.rb
+++ b/lib/octopolo/github/pull_request_creator.rb
@@ -115,10 +115,20 @@ module Octopolo
 
       def edit_body(body)
         return body unless ENV['EDITOR']
+
+        # Open the file, write the contents, and close it
         tempfile = Tempfile.new('octopolo_pull_request')
-        Octopolo::CLI.perform("#{ENV['EDITOR']} #{tempfile.path}")
+        tempfile.write(body)
+        tempfile.close
+
+        # Allow the user to edit the file
+        system "#{ENV['EDITOR']} #{tempfile.path}"
+
+        # Reopen the file, read the contents, and delete it
+        tempfile.open
         output = tempfile.read
         tempfile.unlink
+
         output
       end
 

--- a/lib/octopolo/github/pull_request_creator.rb
+++ b/lib/octopolo/github/pull_request_creator.rb
@@ -117,7 +117,7 @@ module Octopolo
         return body unless ENV['EDITOR']
 
         # Open the file, write the contents, and close it
-        tempfile = Tempfile.new('octopolo_pull_request')
+        tempfile = Tempfile.new(['octopolo_pull_request', '.md'])
         tempfile.write(body)
         tempfile.close
 

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -16,13 +16,15 @@ module Octopolo
       attr_accessor :jira_ids
       attr_accessor :destination_branch
       attr_accessor :label
+      attr_accessor :options
 
-      def self.execute(destination_branch=nil)
-        new(destination_branch).execute
+      def self.execute(destination_branch=nil, options={})
+        new(destination_branch, options).execute
       end
 
-      def initialize(destination_branch=nil)
+      def initialize(destination_branch=nil, options={})
         @destination_branch = destination_branch || default_destination_branch
+        @options = options
       end
 
       def default_destination_branch
@@ -108,6 +110,7 @@ module Octopolo
           source_branch: git.current_branch,
           pivotal_ids: pivotal_ids,
           jira_ids: jira_ids,
+          editor: options[:editor]
         }
       end
       private :pull_request_attributes

--- a/lib/octopolo/user_config.rb
+++ b/lib/octopolo/user_config.rb
@@ -4,6 +4,7 @@ module Octopolo
     attr_accessor :github_user
     attr_accessor :github_token
     attr_accessor :full_name
+    attr_accessor :editor
     attr_accessor :pivotal_token
     attr_accessor :attributes # keep the whole hash
 
@@ -77,6 +78,13 @@ module Octopolo
     # Returns a String
     def full_name
       @full_name || ENV["USER"]
+    end
+
+    # Public: Always use the $EDITOR when available
+    #
+    # Returns a value or false
+    def editor
+      @editor || false
     end
 
     # Public: The GitHub username

--- a/spec/octopolo/github/pull_request_creator_spec.rb
+++ b/spec/octopolo/github/pull_request_creator_spec.rb
@@ -215,6 +215,23 @@ module Octopolo
           Renderer.should_receive(:render).with(Renderer::PULL_REQUEST_BODY, locals) { output }
           creator.body.should == output
         end
+
+        context "when the editor option is set" do
+          let(:edited_output) { stub(:output) }
+
+          before do
+            creator.stub({
+              body_locals: locals,
+              options: { editor: true }
+            })
+          end
+
+          it "calls the edit_body method" do
+            Renderer.should_receive(:render).with(Renderer::PULL_REQUEST_BODY, locals) { output }
+            creator.should_receive(:edit_body).with(output) { edited_output }
+            creator.body.should == edited_output
+          end
+        end
       end
     end
   end

--- a/spec/octopolo/github/pull_request_creator_spec.rb
+++ b/spec/octopolo/github/pull_request_creator_spec.rb
@@ -183,7 +183,7 @@ module Octopolo
           end
 
           it "creates a tempfile, write default contents, and close it" do
-            Tempfile.should_receive(:new) { tempfile }
+            Tempfile.should_receive(:new).with(['octopolo_pull_request', '.md']) { tempfile }
             tempfile.should_receive(:write).with(body)
             tempfile.should_receive(:close)
             creator.edit_body body

--- a/spec/octopolo/scripts/pull_request_spec.rb
+++ b/spec/octopolo/scripts/pull_request_spec.rb
@@ -188,6 +188,7 @@ module Octopolo
             source_branch: git.current_branch,
             pivotal_ids: subject.pivotal_ids,
             jira_ids: subject.jira_ids,
+            editor: nil
           }
         end
       end

--- a/spec/octopolo/user_config_spec.rb
+++ b/spec/octopolo/user_config_spec.rb
@@ -119,6 +119,19 @@ module Octopolo
       end
     end
 
+    context "#editor" do
+      let(:config) { UserConfig.new }
+
+      it "returns the configured value" do
+        config.editor = true
+        config.editor.should == true
+      end
+
+      it "returns false otherwise" do
+        config.editor.should == false
+      end
+    end
+
     context "#github_user" do
       let(:config) { UserConfig.new }
       let(:username) { "joeperson" }


### PR DESCRIPTION
Adds the ability to edit the template for the pull request before it is
created.

This is toggled either via the user config or a command line flag.

Deploy Plan
-----------
* Merge this PR
* Release the gem
* Rejoice along with your other developers about how great this is

Rollback Plan
-------------
This is just so good, why would you want to roll this back?


QA Plan
-------
* Check out this branch
* Run `bundle exec op pull-request -e`
* Before it creates the PR, it should send you to your editor to update the
  description
