### PR TITLE
More helpful errors / Refactor Deployable script

### DIFF
--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -35,7 +35,7 @@ module Octopolo
     def self.client(options = {})
       Octokit::Client.new(options.merge(login: user_config.github_user, access_token: user_config.github_token))
     rescue UserConfig::MissingGitHubAuth
-      raise TryAgain, "No GitHub API token stored. Please run `bundle exec github-auth` to generate your token."
+      raise TryAgain, "No GitHub API token stored. Please run `op github-auth` to generate your token."
     end
 
     # Public: A GitHub client configured to crawl through pages
@@ -48,7 +48,7 @@ module Octopolo
       # we don't care about the output, just try to hit the API
       client.user && nil
     rescue Octokit::Unauthorized
-      raise BadCredentials, "Your stored credentials were rejected by GitHub. Run `bundle exec github-auth` to generate a new token."
+      raise BadCredentials, "Your stored credentials were rejected by GitHub. Run `op github-auth` to generate a new token."
     end
 
     def self.pull_request *args

--- a/lib/octopolo/pull_request_merger.rb
+++ b/lib/octopolo/pull_request_merger.rb
@@ -53,7 +53,7 @@ module Octopolo
       when GitHub::PullRequest::CommentFailed
         cli.say "Unable to write comment. Please navigate to #{pull_request.url} and add the comment, '#{comment_body}'"
       else
-        cli.say "An uknown error occured:  #{e.class.to_s}"
+        cli.say "An unknown error occurred:  #{e.class.to_s}"
       end
       false
     end

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -49,7 +49,7 @@ module Octopolo
         rescue => e
           case e
           when Octokit::Unauthorized
-            cli.say "Your stored credentials were rejected by GitHub. Run `bundle exec github-auth` to generate a new token."
+            cli.say "Your stored credentials were rejected by GitHub. Run `op github-auth` to generate a new token."
           else
             cli.say "An unknown error occurred:  #{e.class.to_s}"
           end

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -25,30 +25,37 @@ module Octopolo
       # Public: Perform the script
       def execute
         self.pull_request_id ||= cli.prompt("Pull Request ID: ")
-        merge_and_label
-      end
-
-      def merge_and_label
         if config.deployable_label
-          ensure_label_was_created
+          with_labelling do
+            merge
+          end
         else
-          PullRequestMerger.perform Git::DEPLOYABLE_PREFIX, Integer(@pull_request_id), :user_notifications => config.user_notifications
+          merge
         end
       end
 
-      def ensure_label_was_created
+      def merge
+        PullRequestMerger.perform Git::DEPLOYABLE_PREFIX, Integer(@pull_request_id), :user_notifications => config.user_notifications
+      end
+      private :merge
+
+      def with_labelling(&block)
         pull_request = Octopolo::GitHub::PullRequest.new(config.github_repo, @pull_request_id)
         begin
           pull_request.add_labels(Deployable.deployable_label)
-          unless PullRequestMerger.perform Git::DEPLOYABLE_PREFIX, Integer(@pull_request_id), :user_notifications => config.user_notifications
+          unless yield
              pull_request.remove_labels(Deployable.deployable_label)
           end
-        rescue Octokit::Error
-
-          cli.say("Unable to mark as deployable, please try command again")
+        rescue => e
+          case e
+          when Octokit::Unauthorized
+            cli.say "Your stored credentials were rejected by GitHub. Run `bundle exec github-auth` to generate a new token."
+          else
+            cli.say "An unknown error occurred:  #{e.class.to_s}"
+          end
         end
       end
-
+      private :with_labelling
     end
   end
 end

--- a/spec/octopolo/github_spec.rb
+++ b/spec/octopolo/github_spec.rb
@@ -24,7 +24,7 @@ module Octopolo
       it "properly handles if the github authentication isn't configured" do
         user_config.should_receive(:github_user).and_raise(UserConfig::MissingGitHubAuth)
         Scripts::GithubAuth.should_not_receive(:invoke)
-        expect { GitHub.client }.to raise_error(GitHub::TryAgain, "No GitHub API token stored. Please run `bundle exec github-auth` to generate your token.")
+        expect { GitHub.client }.to raise_error(GitHub::TryAgain, "No GitHub API token stored. Please run `op github-auth` to generate your token.")
       end
     end
 

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -16,6 +16,7 @@ module Octopolo
         allow(subject).to receive(:config) { config }
         allow(Octopolo::GitHub::PullRequest).to receive(:new) { pull_request }
         allow(PullRequestMerger).to receive(:perform) { true }
+        allow(Octopolo::GitHub).to receive(:check_connection) { true }
       end
 
       context "#execute" do
@@ -62,12 +63,11 @@ module Octopolo
 
           context "with an invalid auth token" do
             before do
-              allow(pull_request).to receive(:add_labels).and_raise(Octokit::Unauthorized)
+              Octopolo::GitHub.stub(:check_connection) { raise GitHub::BadCredentials, "Your stored credentials were rejected by GitHub. Run `op github-auth` to generate a new token." }
             end
 
             it "should give a helpful error message saying your token is invalid" do
-              cli.should_receive(:say)
-                .with("Your stored credentials were rejected by GitHub. Run `op github-auth` to generate a new token.")
+              expect(CLI).to receive(:say).with("Your stored credentials were rejected by GitHub. Run `op github-auth` to generate a new token.")
             end
           end
         end

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -4,92 +4,73 @@ require "octopolo/scripts/deployable"
 module Octopolo
   module Scripts
     describe Deployable do
-      let(:cli) { stub(:Cli) }
-      let(:config) { stub(:user_notifications => ['NickLaMuro'], :github_repo => 'foo', :deployable_label => true) }
-      before { Deployable.any_instance.stub(:cli => cli, :config => config) }
+      subject { described_class.new 42 }
+
+      let(:cli) { stub(prompt: 42) }
+      let(:config) { stub(user_notifications: ['NickLaMuro'],
+                          github_repo: 'grumpy_cat',
+                          deployable_label: true) }
+      let(:pull_request) { stub(add_labels: true, remove_labels: true) }
+      before do
+        allow(subject).to receive(:cli) { cli }
+        allow(subject).to receive(:config) { config }
+        allow(Octopolo::GitHub::PullRequest).to receive(:new) { pull_request }
+        allow(PullRequestMerger).to receive(:perform) { true }
+      end
 
       context "#execute" do
-        subject { Deployable.new 42}
-        it "calls merge_and_label" do
-          expect(subject).to receive(:merge_and_label)
+        after do
           subject.execute
         end
 
-        context "#merge_and_label" do
-          before do
-            allow(PullRequestMerger).to receive(:perform)
+        context "with a PR ID passed in with the command" do
+          it "doesn't prompt for a PR ID" do
+            cli.should_not_receive(:prompt)
+          end
+        end
+
+        context "without a PR ID passed in with the command" do
+          subject { described_class.new }
+
+          it "prompts for a PR ID" do
+            cli.should_receive(:prompt)
+              .with("Pull Request ID: ")
+              .and_return("42")
+          end
+        end
+
+        context "with labelling enabled" do
+          it "adds the deployable label" do
+            pull_request.should_receive(:add_labels)
           end
 
-          context "deployable_label is set to true" do
-            it "calls ensure_label_was_created" do
-              expect(subject).to receive(:ensure_label_was_created)
-              subject.execute
+          context "when merge to deployable fails" do
+            before do
+              allow(PullRequestMerger).to receive(:perform) { false }
+            end
+
+            it "removes the deployable label" do
+              pull_request.should_receive(:remove_labels)
             end
           end
 
-          context "deployable_label is set to false " do 
-            let(:config) { stub(:user_notifications => ['NickLaMuro'], :github_repo => 'foo', :deployable_label => false) }
-            it "skips add_to_pull when deployable_label is false" do
-              expect(subject).to_not receive(:ensure_label_was_created)
-              subject.execute
+          context "when the merge to deployable succeeds" do
+            it "doesn't remove the deployable label" do
+              pull_request.should_not_receive(:remove_labels)
             end
+          end
+        end
+
+        context "with labelling disabled" do
+          let(:config) { stub(user_notifications: ['NickLaMuro'],
+                              github_repo: 'grumpy_cat',
+                              deployable_label: false) }
+
+          it "doesn't add the deployable label" do
+            pull_request.should_not_receive(:add_labels)
           end
         end
       end
-
-      context "#ensure_label_was_created" do
-        subject { Deployable.new 42}
-        let(:pull_request) {Octopolo::GitHub::PullRequest.new('foo', subject.pull_request_id, nil)}
-        before do
-          allow_any_instance_of(Octopolo::GitHub::PullRequest).to receive(:add_labels)
-        end
-
-        context "with a PR passed in via the command args" do
-          it "delegates the work to PullRequestMerger" do
-            expect(PullRequestMerger).to receive(:perform).with(Git::DEPLOYABLE_PREFIX, 42, :user_notifications => ["NickLaMuro"]) {true}
-            subject.ensure_label_was_created
-          end
-        end
-
-        context "with no PR passed in from the command args" do
-          subject { Deployable.new }
-
-          context "with a PR passed in through the cli" do
-            before do
-              cli.should_receive(:prompt)
-                 .with("Pull Request ID: ")
-                 .and_return("42")
-            end
-
-            it "delegates the work to PullRequestMerger" do
-              expect(PullRequestMerger).to receive(:perform).with(Git::DEPLOYABLE_PREFIX, 42, :user_notifications => ["NickLaMuro"]) {true}
-              subject.execute
-            end
-          end
-
-          context "with no PR passed in from the cli" do
-            before do
-              cli.should_receive(:prompt)
-                 .with("Pull Request ID: ")
-                 .and_return("foo")
-            end
-
-            it "delegates the work to PullRequestMerger" do
-              expect{ subject.execute }.to raise_error(ArgumentError)
-            end
-          end
-        end
-
-        context "when it creates a label successfully" do
-
-          it "calls remove_label when pull_request_merge fails" do
-            allow(PullRequestMerger).to receive(:perform) {nil}
-            expect_any_instance_of(Octopolo::GitHub::PullRequest).to receive(:remove_labels)
-            subject.ensure_label_was_created
-          end
-        end
-      end
-      
     end
   end
 end

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -59,6 +59,17 @@ module Octopolo
               pull_request.should_not_receive(:remove_labels)
             end
           end
+
+          context "with an invalid auth token" do
+            before do
+              allow(pull_request).to receive(:add_labels).and_raise(Octokit::Unauthorized)
+            end
+
+            it "should give a helpful error message saying your token is invalid" do
+              cli.should_receive(:say)
+                .with("Your stored credentials were rejected by GitHub. Run `op github-auth` to generate a new token.")
+            end
+          end
         end
 
         context "with labelling disabled" do


### PR DESCRIPTION
I took inventory of my OAuth tokens over the weekend and likely revoked the one that Octopolo was using. Upon trying to mark a branch as deployable, got the unhelpful "Sorry, can't mark as deployable, try again?" message. I discovered later it was because it was unauthorized, but decided to make this error message more helpful for the future (as many of the other commands, specifically anything to do with `PullRequestMerger`, rightfully try to tell you that you are unauthorized and should generate a new token). Refactored the deployable script to smell a little less, while I was at it. 

QA:
Honestly I bet @NickLaMuro has more of an idea what to look for with `deployable` if I botched anything up, but here are some standards...

- [ ] When you don't have a token or it's invalid, `op deployable` should give you a helpful error message indicating you need to generate a new token.
- [ ] When you do have a valid token, the command should work exactly as it always has.

See detailed specs I wrote for other behaviors. 