### PR TITLE
Add new autocomplete_commands toggle; fixes #34

### DIFF
--- a/bin/op
+++ b/bin/op
@@ -8,6 +8,7 @@ include GLI::App
 program_desc 'GitHub workflow scripts. From the Ngineers at Sport Ngin.'
 version Octopolo::VERSION
 
+autocomplete_commands false
 wrap_help_text :verbatim
 
 program_long_desc """

--- a/octopolo.gemspec
+++ b/octopolo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Octopolo::VERSION
 
   gem.add_dependency 'rake'
-  gem.add_dependency 'gli', '~> 2.10'
+  gem.add_dependency 'gli', '~> 2.13'
   gem.add_dependency 'hashie', '~> 1.2'
   gem.add_dependency 'octokit', '~> 2.7.1'
   gem.add_dependency 'highline', '~> 1.6'


### PR DESCRIPTION
Added a new `autocomplete_commands <boolean>` toggle to GLI, released in 2.13.0 (form this PR: https://github.com/davetron5000/gli/pull/211). This fixes the issue of partial commands doing bad things, such as `op deploy` -> `op deployable`. 

QA:

Easiest QA is just building this branch locally, installing it in a project, and trying `sync`. Should _not_ execute `sync-branch` but instead throw an UnknownCommand error.