### PR TITLE
Errors from CLI commands should throw and exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ test/tmp
 test/version_tmp
 tmp
 log/
+.idea
 
 # YARD artifacts
 .yardoc

--- a/lib/octopolo/cli.rb
+++ b/lib/octopolo/cli.rb
@@ -26,7 +26,7 @@ module Octopolo
       # and then perform it
       if Open3.respond_to?(:capture3)
         output, error, status = Open3.capture3(command)
-        raise "exit_status=#{status.exitstatus}; stderr=#{error}" if status.nil? || !status.success?
+        raise "exit_status=#{status.exitstatus}; stderr=#{error}" unless status.success?
       else
         # Only necessary as long as we use 1.8.7, which doesn't have Open3.capture3
         output = `#{command}`

--- a/lib/octopolo/cli.rb
+++ b/lib/octopolo/cli.rb
@@ -26,6 +26,7 @@ module Octopolo
       # and then perform it
       if Open3.respond_to?(:capture3)
         output, error, status = Open3.capture3(command)
+        raise "exit_status=#{status}; stderr=#{error}"
       else
         # Only necessary as long as we use 1.8.7, which doesn't have Open3.capture3
         output = `#{command}`

--- a/lib/octopolo/cli.rb
+++ b/lib/octopolo/cli.rb
@@ -26,7 +26,7 @@ module Octopolo
       # and then perform it
       if Open3.respond_to?(:capture3)
         output, error, status = Open3.capture3(command)
-        raise "exit_status=#{status}; stderr=#{error}"
+        raise "exit_status=#{status.exitstatus}; stderr=#{error}" if status.nil? || !status.success?
       else
         # Only necessary as long as we use 1.8.7, which doesn't have Open3.capture3
         output = `#{command}`

--- a/spec/octopolo/cli_spec.rb
+++ b/spec/octopolo/cli_spec.rb
@@ -26,10 +26,17 @@ module Octopolo
         subject.perform(command).should == result
       end
 
-      it "should handle errors gracefully" do
+      it "should handle exception gracefully" do
         subject.should_receive(:say).with(command)
         Open3.should_receive(:capture3).with(command).and_raise(exception_message)
         subject.should_receive(:say).with("Unable to perform '#{command}': #{exception_message}")
+        subject.perform(command).should be_nil
+      end
+
+      it "should handle errors gracefully" do
+        subject.should_receive(:say).with(command)
+        Open3.should_receive(:capture3).with(command).and_return([result, "kaboom", 1])
+        subject.should_receive(:say).with("Unable to perform '#{command}': exit_status=1; stderr=kaboom")
         subject.perform(command).should be_nil
       end
 

--- a/spec/octopolo/cli_spec.rb
+++ b/spec/octopolo/cli_spec.rb
@@ -10,7 +10,6 @@ module Octopolo
       let(:error) { "error message" }
       let(:exception_message) { "Error with something" }
       let(:status_success) { double("status", "success?" => true, :exitstatus => 0) }
-      let(:status_incomplete) { double("status", "success?" => nil, :exitstatus => nil) }
       let(:status_error) { double("status", "success?" => nil, :exitstatus => 1) }
 
       it "passes the given command to the shell" do
@@ -40,13 +39,6 @@ module Octopolo
         subject.should_receive(:say).with(command)
         Open3.should_receive(:capture3).with(command).and_return([result, "kaboom", status_error])
         subject.should_receive(:say).with("Unable to perform '#{command}': exit_status=1; stderr=kaboom")
-        subject.perform(command).should be_nil
-      end
-
-      it "should handle incomplete commands gracefully" do
-        subject.should_receive(:say).with(command)
-        Open3.should_receive(:capture3).with(command).and_return([result, "kaboom", status_incomplete])
-        subject.should_receive(:say).with("Unable to perform '#{command}': exit_status=; stderr=kaboom")
         subject.perform(command).should be_nil
       end
 


### PR DESCRIPTION
Errors in CLI commands are currently being ignored silently.  This changes command errors to be raised and handled like other exceptions.  Errors will now be show to the user for review.