### PR TITLE
Command Errors Should Not Be Rescued

### DIFF
--- a/lib/octopolo/cli.rb
+++ b/lib/octopolo/cli.rb
@@ -26,7 +26,7 @@ module Octopolo
       # and then perform it
       if Open3.respond_to?(:capture3)
         output, error, status = Open3.capture3(command)
-        raise "exit_status=#{status.exitstatus}; stderr=#{error}" unless status.success?
+        raise "command=#{command}; exit_status=#{status.exitstatus}; stderr=#{error}" unless status.success?
       else
         # Only necessary as long as we use 1.8.7, which doesn't have Open3.capture3
         output = `#{command}`
@@ -36,8 +36,6 @@ module Octopolo
       say output if say_command
       # return the output of the command
       output
-    rescue => e
-      say "Unable to perform '#{command}': #{e.message}"
     end
 
     # Public: Perform the command, but do not print out the command

--- a/lib/octopolo/git.rb
+++ b/lib/octopolo/git.rb
@@ -88,7 +88,7 @@ module Octopolo
     def self.new_branch(new_branch_name, source_branch_name)
       fetch
       perform("branch --no-track #{new_branch_name} origin/#{source_branch_name}")
-      check_out new_branch_name
+      check_out(new_branch_name, false)
       perform("push --set-upstream origin #{new_branch_name}")
     end
 

--- a/lib/octopolo/git.rb
+++ b/lib/octopolo/git.rb
@@ -67,10 +67,11 @@ module Octopolo
     # Public: Check out the given branch name
     #
     # branch_name - The name of the branch to check out
-    def self.check_out branch_name
+    # do_after_pull - Should a pull be done after checkout?
+    def self.check_out(branch_name, do_after_pull=true)
       fetch
       perform "checkout #{branch_name}"
-      pull
+      pull if do_after_pull
       unless current_branch == branch_name
         raise CheckoutFailed, "Failed to check out '#{branch_name}'"
       end

--- a/spec/octopolo/cli_spec.rb
+++ b/spec/octopolo/cli_spec.rb
@@ -31,17 +31,14 @@ module Octopolo
       it "should raise exception" do
         subject.should_receive(:say).with(command)
         Open3.should_receive(:capture3).with(command).and_raise(exception_message)
-        expect do
-          subject.perform(command)
-        end.to raise_error(RuntimeError, exception_message)
+        expect { subject.perform(command) }.to raise_error(RuntimeError, exception_message)
       end
 
       it "should raise errors from command" do
         subject.should_receive(:say).with(command)
         Open3.should_receive(:capture3).with(command).and_return([result, "kaboom", status_error])
-        expect do
-          subject.perform(command)
-        end.to raise_error(RuntimeError, "command=#{command}; exit_status=1; stderr=kaboom")
+        expect { subject.perform(command) }
+            .to raise_error(RuntimeError, "command=#{command}; exit_status=1; stderr=kaboom")
       end
 
       it "should not speak the command if told not to" do

--- a/spec/octopolo/cli_spec.rb
+++ b/spec/octopolo/cli_spec.rb
@@ -28,18 +28,20 @@ module Octopolo
         subject.perform(command).should == result
       end
 
-      it "should handle exception gracefully" do
+      it "should raise exception" do
         subject.should_receive(:say).with(command)
         Open3.should_receive(:capture3).with(command).and_raise(exception_message)
-        subject.should_receive(:say).with("Unable to perform '#{command}': #{exception_message}")
-        subject.perform(command).should be_nil
+        expect do
+          subject.perform(command)
+        end.to raise_error(RuntimeError, exception_message)
       end
 
-      it "should handle errors gracefully" do
+      it "should raise errors from command" do
         subject.should_receive(:say).with(command)
         Open3.should_receive(:capture3).with(command).and_return([result, "kaboom", status_error])
-        subject.should_receive(:say).with("Unable to perform '#{command}': exit_status=1; stderr=kaboom")
-        subject.perform(command).should be_nil
+        expect do
+          subject.perform(command)
+        end.to raise_error(RuntimeError, "command=#{command}; exit_status=1; stderr=kaboom")
       end
 
       it "should not speak the command if told not to" do

--- a/spec/octopolo/git_spec.rb
+++ b/spec/octopolo/git_spec.rb
@@ -79,6 +79,14 @@ module Octopolo
         Git.check_out name
       end
 
+      it "checks out the given branch name without after pull" do
+        Git.should_receive(:fetch)
+        Git.should_receive(:perform).with("checkout #{name}")
+        Git.should_not_receive(:pull)
+        Git.should_receive(:current_branch) { name }
+        Git.check_out(name, false)
+      end
+
       it "raises an exception if the current branch is not the requested branch afterward" do
         Git.should_receive(:fetch)
         Git.should_receive(:perform)

--- a/spec/octopolo/git_spec.rb
+++ b/spec/octopolo/git_spec.rb
@@ -353,7 +353,7 @@ module Octopolo
       it "creates and pushes a new branch from the source branch" do
         Git.should_receive(:fetch)
         Git.should_receive(:perform).with("branch --no-track #{new_branch_name} origin/#{source_branch_name}")
-        Git.should_receive(:check_out).with(new_branch_name)
+        Git.should_receive(:check_out).with(new_branch_name, false)
         Git.should_receive(:perform).with("push --set-upstream origin #{new_branch_name}")
 
         Git.new_branch(new_branch_name, source_branch_name)


### PR DESCRIPTION
A command error should halt further actions, bubble up and return a non-zero from octopolo.  If something goes wrong with a command, we likely don't want to continue actions in an unknown state.  Also, for using octopolo in scripting it is useful to have a non-zero return code when something went wrong.