### PR TITLE
Adding delete flag to dated branch creation commands for non-interactive support

### DIFF
--- a/lib/octopolo/commands/new_deployable.rb
+++ b/lib/octopolo/commands/new_deployable.rb
@@ -5,7 +5,9 @@ Useful when we have changes in the current deployable branch that we wish to rem
 command 'new-deployable' do |c|
   c.switch :delete_old_branches, :default_value => false, :desc => "Should old deployable branches be deleted?", :negatable => false
 
-  require_relative '../scripts/new_deployable'
-  options = global_options.merge(options)
-  c.action { Octopolo::Scripts::NewDeployable.new.execute(options[:delete_old_branches]) }
+  c.action do |global_options, options, args|
+    require_relative '../scripts/new_deployable'
+    options = global_options.merge(options)
+    Octopolo::Scripts::NewDeployable.new.execute(options[:delete_old_branches])
+  end
 end

--- a/lib/octopolo/commands/new_deployable.rb
+++ b/lib/octopolo/commands/new_deployable.rb
@@ -8,6 +8,6 @@ command 'new-deployable' do |c|
   c.action do |global_options, options, args|
     require_relative '../scripts/new_deployable'
     options = global_options.merge(options)
-    Octopolo::Scripts::NewDeployable.new.execute(options[:delete_old_branches])
+    Octopolo::Scripts::NewDeployable.new.execute(options)
   end
 end

--- a/lib/octopolo/commands/new_deployable.rb
+++ b/lib/octopolo/commands/new_deployable.rb
@@ -3,6 +3,9 @@ long_desc "Create a new deployable branch with today's date and remove the other
 
 Useful when we have changes in the current deployable branch that we wish to remove."
 command 'new-deployable' do |c|
+  c.switch :delete_old_branches, :default_value => false, :desc => "Should old deployable branches be deleted?", :negatable => false
+
   require_relative '../scripts/new_deployable'
-  c.action { Octopolo::Scripts::NewDeployable.new.execute }
+  options = global_options.merge(options)
+  c.action { Octopolo::Scripts::NewDeployable.new.execute(options[:delete_old_branches]) }
 end

--- a/lib/octopolo/commands/new_staging.rb
+++ b/lib/octopolo/commands/new_staging.rb
@@ -5,7 +5,9 @@ Useful when we have changes in the current staging branch that we wish to remove
 command 'new-staging' do |c|
   c.switch :delete_old_branches, :default_value => false, :desc => "Should old staging branches be deleted?", :negatable => false
 
-  require_relative '../scripts/new_staging'
-  options = global_options.merge(options)
-  c.action { Octopolo::Scripts::NewStaging.new.execute(options[:delete_old_branches]) }
+  c.action do |global_options, options, args|
+    require_relative '../scripts/new_staging'
+    options = global_options.merge(options)
+    Octopolo::Scripts::NewStaging.new.execute(options[:delete_old_branches])
+  end
 end

--- a/lib/octopolo/commands/new_staging.rb
+++ b/lib/octopolo/commands/new_staging.rb
@@ -8,6 +8,6 @@ command 'new-staging' do |c|
   c.action do |global_options, options, args|
     require_relative '../scripts/new_staging'
     options = global_options.merge(options)
-    Octopolo::Scripts::NewStaging.new.execute(options[:delete_old_branches])
+    Octopolo::Scripts::NewStaging.new.execute(options)
   end
 end

--- a/lib/octopolo/commands/new_staging.rb
+++ b/lib/octopolo/commands/new_staging.rb
@@ -3,6 +3,9 @@ long_desc "Create a new staging branch with today's date and remove the others.
 
 Useful when we have changes in the current staging branch that we wish to remove."
 command 'new-staging' do |c|
+  c.switch :delete_old_branches, :default_value => false, :desc => "Should old staging branches be deleted?", :negatable => false
+
   require_relative '../scripts/new_staging'
-  c.action { Octopolo::Scripts::NewStaging.new.execute }
+  options = global_options.merge(options)
+  c.action { Octopolo::Scripts::NewStaging.new.execute(options[:delete_old_branches]) }
 end

--- a/lib/octopolo/dated_branch_creator.rb
+++ b/lib/octopolo/dated_branch_creator.rb
@@ -9,20 +9,24 @@ module Octopolo
     include GitWrapper
 
     attr_accessor :branch_type
+    attr_accessor :should_delete_old_branches
 
     # Public: Initialize a new instance of DatedBranchCreator
     #
     # branch_type - Name of the type of branch (e.g., staging or deployable)
-    def initialize(branch_type)
+    # should_delete_old_branches - Flag to delete old branches of the given type.
+    def initialize(branch_type, should_delete_old_branches=false)
       self.branch_type = branch_type
+      self.should_delete_old_branches = should_delete_old_branches
     end
 
     # Public: Create a new branch of the given type for today's date
     #
     # branch_type - Name of the type of branch (e.g., staging or deployable)
+    # should_delete_old_branches - Flag to delete old branches of the given type.
     #
     # Returns a DatedBranchCreator
-    def self.perform(branch_type)
+    def self.perform(branch_type, should_delete_old_branches=false)
       new(branch_type).tap do |creator|
         creator.perform
       end
@@ -56,7 +60,10 @@ module Octopolo
 
     # Public: If necessary, and if user opts to, delete old branches of its type
     def delete_old_branches
-      if extra_branches.any? && cli.ask_boolean("Do you want to delete the old #{branch_type} branch(es)? (#{extra_branches.join(", ")})")
+      return unless extra_branches.any?
+      should_delete = should_delete_old_branches || cli.ask_boolean("Do you want to delete the old #{branch_type} branch(es)? (#{extra_branches.join(", ")})")
+
+      if should_delete
         extra_branches.each do |extra|
           Git.delete_branch(extra)
         end

--- a/lib/octopolo/scripts/new_deployable.rb
+++ b/lib/octopolo/scripts/new_deployable.rb
@@ -5,8 +5,8 @@ module Octopolo
   module Scripts
     class NewDeployable
 
-      def execute
-        DatedBranchCreator.perform Git::DEPLOYABLE_PREFIX
+      def execute(delete_old_branches=false)
+        DatedBranchCreator.perform(Git::DEPLOYABLE_PREFIX, delete_old_branches)
       end
     end
   end

--- a/lib/octopolo/scripts/new_deployable.rb
+++ b/lib/octopolo/scripts/new_deployable.rb
@@ -5,8 +5,8 @@ module Octopolo
   module Scripts
     class NewDeployable
 
-      def execute(delete_old_branches=false)
-        DatedBranchCreator.perform(Git::DEPLOYABLE_PREFIX, delete_old_branches)
+      def execute(options={:delete_old_branches => false})
+        DatedBranchCreator.perform(Git::DEPLOYABLE_PREFIX, options[:delete_old_branches])
       end
     end
   end

--- a/lib/octopolo/scripts/new_staging.rb
+++ b/lib/octopolo/scripts/new_staging.rb
@@ -6,8 +6,8 @@ module Octopolo
     class NewStaging
       include CLIWrapper
 
-      def execute
-        DatedBranchCreator.perform Git::STAGING_PREFIX
+      def execute(delete_old_branches=false)
+        DatedBranchCreator.perform(Git::STAGING_PREFIX, delete_old_branches)
       end
     end
   end

--- a/lib/octopolo/scripts/new_staging.rb
+++ b/lib/octopolo/scripts/new_staging.rb
@@ -6,8 +6,8 @@ module Octopolo
     class NewStaging
       include CLIWrapper
 
-      def execute(delete_old_branches=false)
-        DatedBranchCreator.perform(Git::STAGING_PREFIX, delete_old_branches)
+      def execute(options={:delete_old_branches => false})
+        DatedBranchCreator.perform(Git::STAGING_PREFIX, options[:delete_old_branches])
       end
     end
   end

--- a/spec/octopolo/dated_branch_creator_spec.rb
+++ b/spec/octopolo/dated_branch_creator_spec.rb
@@ -112,6 +112,21 @@ module Octopolo
           cli.should_not_receive(:perform)
           subject.delete_old_branches
         end
+
+        context "delete flag" do
+          before do
+            subject.stub(extra_branches: extras)
+            subject.should_delete_old_branches = true
+          end
+
+          it "deletes these branches non-interactively" do
+            cli.should_not_receive(:ask_boolean).with(message)
+            extras.each do |extra|
+              Git.should_receive(:delete_branch).with(extra)
+            end
+            subject.delete_old_branches
+          end
+        end
       end
     end
 

--- a/spec/octopolo/scripts/new_deployable_spec.rb
+++ b/spec/octopolo/scripts/new_deployable_spec.rb
@@ -13,7 +13,7 @@ module Octopolo
         end
         it "delegates the work to DatedBranchCreator with delete flag" do
           DatedBranchCreator.should_receive(:perform).with(Git::DEPLOYABLE_PREFIX, true)
-          subject.execute(true)
+          subject.execute(:delete_old_branches => true)
         end
       end
     end

--- a/spec/octopolo/scripts/new_deployable_spec.rb
+++ b/spec/octopolo/scripts/new_deployable_spec.rb
@@ -7,9 +7,13 @@ module Octopolo
       subject { NewDeployable.new }
 
       context "#execute" do
-        it "delegates the work to DatedBranchCreator" do
-          DatedBranchCreator.should_receive(:perform).with(Git::DEPLOYABLE_PREFIX)
+        it "delegates the work to DatedBranchCreator with default delete flag" do
+          DatedBranchCreator.should_receive(:perform).with(Git::DEPLOYABLE_PREFIX, false)
           subject.execute
+        end
+        it "delegates the work to DatedBranchCreator with delete flag" do
+          DatedBranchCreator.should_receive(:perform).with(Git::DEPLOYABLE_PREFIX, true)
+          subject.execute(true)
         end
       end
     end

--- a/spec/octopolo/scripts/new_staging_spec.rb
+++ b/spec/octopolo/scripts/new_staging_spec.rb
@@ -13,7 +13,7 @@ module Octopolo
         end
         it "delegates to DatedBranchCreator to create the branch with delete flag" do
           DatedBranchCreator.should_receive(:perform).with(Git::STAGING_PREFIX, true)
-          subject.execute(true)
+          subject.execute(:delete_old_branches => true)
         end
       end
     end

--- a/spec/octopolo/scripts/new_staging_spec.rb
+++ b/spec/octopolo/scripts/new_staging_spec.rb
@@ -7,9 +7,13 @@ module Octopolo
       subject { NewStaging.new }
 
       context "#execute" do
-        it "delegates to DatedBranchCreator to create the branch" do
-          DatedBranchCreator.should_receive(:perform).with(Git::STAGING_PREFIX)
+        it "delegates to DatedBranchCreator to create the branch with default delete flag" do
+          DatedBranchCreator.should_receive(:perform).with(Git::STAGING_PREFIX, false)
           subject.execute
+        end
+        it "delegates to DatedBranchCreator to create the branch with delete flag" do
+          DatedBranchCreator.should_receive(:perform).with(Git::STAGING_PREFIX, true)
+          subject.execute(true)
         end
       end
     end


### PR DESCRIPTION
`new-staging` and `new-deployable` have a new flag to delete old branches of that type.  This behavior was already implemented but could only be enabled through a interactive prompt response.  These additions allow for non-interactive scripting usage without resorting to something like expect.