### PR TITLE
Adding issue command to create issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: false
+branches:
+  only:
+    - master
 language: ruby
 rvm:
   - 1.9.3

--- a/lib/octopolo/commands/issue.rb
+++ b/lib/octopolo/commands/issue.rb
@@ -1,0 +1,14 @@
+desc "Create an issue for the current project."
+command 'issue' do |c|
+  config = Octopolo::Config.parse
+  user_config = Octopolo::UserConfig.parse
+
+  c.desc "Use $EDITOR to update PR description before creating"
+  c.switch [:e, :editor], :default_value => user_config.editor
+
+  c.action do |global_options, options, args|
+    require_relative '../scripts/issue'
+    options = global_options.merge(options)
+    Octopolo::Scripts::Issue.execute options
+  end
+end

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -109,10 +109,6 @@ module Octopolo
       client.remove_label *args
     end
 
-    def self.add_labels_to_pull *args
-      client.add_labels_to_an_issue *args
-    end
-
     def self.add_labels_to_issue *args
       client.add_labels_to_an_issue *args
     end

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -71,6 +71,14 @@ module Octopolo
       client.create_pull_request *args
     end
 
+    def self.issue *args
+      client.issue *args
+    end
+
+    def self.create_issue *args
+      client.create_issue *args
+    end
+
     def self.add_comment *args
       client.add_comment *args
     end
@@ -105,6 +113,9 @@ module Octopolo
       client.add_labels_to_an_issue *args
     end
 
+    def self.add_labels_to_issue *args
+      client.add_labels_to_an_issue *args
+    end
 
 
     # now that you've set up your credentials, try again

--- a/lib/octopolo/github/issue.rb
+++ b/lib/octopolo/github/issue.rb
@@ -3,16 +3,16 @@ require "octokit"
 module Octopolo
   module GitHub
     class Issue
-      attr_accessor :issue_data
+      attr_accessor :data
       attr_accessor :repo_name
       attr_accessor :number
 
-      def initialize repo_name, number, issue_data = nil
+      def initialize repo_name, number, data = nil
         raise MissingParameter if repo_name.nil? or number.nil?
 
         self.repo_name = repo_name
         self.number = number
-        self.issue_data = issue_data
+        self.data = data
       end
 
       # Public: Create a issue for the given repo
@@ -27,33 +27,33 @@ module Octopolo
         # create via the API
         creator = IssueCreator.perform(repo_name, options)
         # wrap in our class
-        new repo_name, creator.number, creator.issue_data
+        new repo_name, creator.number, creator.data
       end
 
-      def issue_data
-        @issue_data ||= GitHub.issue(repo_name, number)
+      def data
+        @data ||= GitHub.issue(repo_name, number)
       rescue Octokit::NotFound
         raise NotFound
       end
 
       def title
-        issue_data.title
+        data.title
       end
 
       def url
-        issue_data.html_url
+        data.html_url
       end
 
       def commenter_names
-        exlude_octopolo_user (comments.map{ |comment| GitHub::User.new(comment.user.login).author_name }.uniq)
+        exclude_octopolo_user (comments.map{ |comment| GitHub::User.new(comment.user.login).author_name }.uniq)
       end
 
-      def exlude_octopolo_user(user_list)
+      def exclude_octopolo_user(user_list)
         user_list.reject{|u| GitHub.excluded_users.include?(u) }
       end
 
       def body
-        issue_data.body || ""
+        data.body || ""
       end
 
       def external_urls

--- a/lib/octopolo/github/issue.rb
+++ b/lib/octopolo/github/issue.rb
@@ -1,0 +1,106 @@
+require "octokit"
+
+module Octopolo
+  module GitHub
+    class Issue
+      attr_accessor :issue_data
+      attr_accessor :repo_name
+      attr_accessor :number
+
+      def initialize repo_name, number, issue_data = nil
+        raise MissingParameter if repo_name.nil? or number.nil?
+
+        self.repo_name = repo_name
+        self.number = number
+        self.issue_data = issue_data
+      end
+
+      # Public: Create a issue for the given repo
+      #
+      # repo_name - Full name ("account/repo") of the repo in question
+      # options - Hash of issue information
+      #   title: Title of the issue
+      #   description: Brief description of the issue
+      #
+      # Returns a Issue instance
+      def self.create(repo_name, options)
+        # create via the API
+        creator = IssueCreator.perform(repo_name, options)
+        # wrap in our class
+        new repo_name, creator.number, creator.issue_data
+      end
+
+      def issue_data
+        @issue_data ||= GitHub.issue(repo_name, number)
+      rescue Octokit::NotFound
+        raise NotFound
+      end
+
+      def title
+        issue_data.title
+      end
+
+      def url
+        issue_data.html_url
+      end
+
+      def commenter_names
+        exlude_octopolo_user (comments.map{ |comment| GitHub::User.new(comment.user.login).author_name }.uniq)
+      end
+
+      def exlude_octopolo_user(user_list)
+        user_list.reject{|u| GitHub.excluded_users.include?(u) }
+      end
+
+      def body
+        issue_data.body || ""
+      end
+
+      def external_urls
+        # extract http and https URLs from the body
+        URI.extract body, %w(http https)
+      end
+
+      def human_app_name
+        repo = repo_name.split("/").last
+        repo.split("_").map(&:capitalize).join(" ")
+      end
+
+      def comments
+        @comments ||= GitHub.issue_comments(repo_name, number)
+      end
+
+      # Public: Add a comment to the issue
+      #
+      # message - A String containing the desired comment body
+      def write_comment(message)
+        GitHub.add_comment repo_name, number, ":octocat: #{message}"
+      rescue Octokit::UnprocessableEntity => error
+        raise CommentFailed, "Unable to write the comment: '#{error.message}'"
+      end
+
+      # Public: Adds labels to a pull-request
+      #
+      # labels - label objects, can be a single label, an array of labels,
+      #          or a list of labels
+      def add_labels(*labels)
+        built_labels = Label.build_label_array(labels)
+        GitHub.add_labels_to_issue(repo_name, number, built_labels.map(&:name) )
+      end
+
+      # Public: Removes labels from a pull-request,
+      #
+      # labels - label objects, can be a single label, an array of labels,
+      #          or a list of labels
+      def remove_labels(*labels)
+        Label.build_label_array(labels).each do |built_label|
+          GitHub.remove_label(repo_name, number, built_label.name)
+        end
+      end
+
+      MissingParameter = Class.new StandardError
+      NotFound = Class.new StandardError
+      CommentFailed = Class.new StandardError
+    end
+  end
+end

--- a/lib/octopolo/github/issue_creator.rb
+++ b/lib/octopolo/github/issue_creator.rb
@@ -1,0 +1,131 @@
+require_relative "../renderer"
+require 'tempfile'
+
+module Octopolo
+  module GitHub
+    class IssueCreator
+      include ConfigWrapper
+      # for instantiating the issue creator
+      attr_accessor :repo_name
+      attr_accessor :options
+      # for caputuring the created issue information
+      attr_accessor :number
+      attr_accessor :issue_data
+
+      # Public: Create a issue for the given repo with the given options
+      #
+      # repo_name - Full name ("account/repo") of the repo in question
+      # options - Hash of issue information
+      #   title: Title of the issue
+      def initialize repo_name, options
+        self.repo_name = repo_name
+        self.options = options
+      end
+
+      # Public: Create a issue for the given repo with the given options
+      #
+      # repo_name - Full name ("account/repo") of the repo in question
+      # options - Hash of issue information
+      #   title: Title of the issue
+      #
+      # Returns the IssueCreator instance
+      def self.perform repo_name, options
+        new(repo_name, options).tap do |creator|
+          creator.perform
+        end
+      end
+
+      # Public: Create the issue
+      #
+      # Returns an array with the first element being the issue's
+      # number, the second being a Mash of the response from GitHub's API
+      def perform
+        result = GitHub.create_issue(repo_name, title, body)
+        # capture the information
+        self.number = result.number
+        self.issue_data = result
+      rescue => e
+        raise CannotCreate, e.message
+      end
+
+      # Public: The created issue's details
+      def issue_data
+        @issue_data || raise(NotYetCreated)
+      end
+
+      # Public: The created issue's number
+      def number
+        @number || raise(NotYetCreated)
+      end
+
+      # Public: Title of the issue
+      #
+      # Returns a String with the title
+      def title
+        options[:title] || raise(MissingAttribute)
+      end
+
+      # Public: The Pivotal Tracker story IDs associated with the issue
+      #
+      # Returns an Array of Strings
+      def pivotal_ids
+        options[:pivotal_ids] || []
+      end
+
+      # Public: Jira Issue IDs associated with the issue
+      #
+      # Returns an Array of Strings
+      def jira_ids
+        options[:jira_ids] || []
+      end
+
+      # Public: Jira Url associated with the issue
+      #
+      # Returns Jira Url
+      def jira_url
+        config.jira_url
+      end
+
+      # Public: The body (primary copy) of the issue
+      #
+      # Returns a String
+      def body
+        output = Renderer.render Renderer::ISSUE_BODY, body_locals
+        output = edit_body(output) if options[:editor]
+        output
+      end
+
+      def edit_body(body)
+        return body unless ENV['EDITOR']
+
+        # Open the file, write the contents, and close it
+        tempfile = Tempfile.new(['octopolo_issue', '.md'])
+        tempfile.write(body)
+        tempfile.close
+
+        # Allow the user to edit the file
+        system "#{ENV['EDITOR']} #{tempfile.path}"
+
+        # Reopen the file, read the contents, and delete it
+        tempfile.open
+        output = tempfile.read
+        tempfile.unlink
+
+        output
+      end
+
+      # Public: The local variables to pass into the template
+      def body_locals
+        {
+          pivotal_ids: pivotal_ids,
+          jira_ids: jira_ids,
+          jira_url: jira_url,
+        }
+      end
+
+      MissingAttribute = Class.new(StandardError)
+      NotYetCreated = Class.new(StandardError)
+      CannotCreate = Class.new(StandardError)
+    end
+  end
+end

--- a/lib/octopolo/github/issue_creator.rb
+++ b/lib/octopolo/github/issue_creator.rb
@@ -10,7 +10,7 @@ module Octopolo
       attr_accessor :options
       # for caputuring the created issue information
       attr_accessor :number
-      attr_accessor :issue_data
+      attr_accessor :data
 
       # Public: Create a issue for the given repo with the given options
       #
@@ -43,14 +43,14 @@ module Octopolo
         result = GitHub.create_issue(repo_name, title, body)
         # capture the information
         self.number = result.number
-        self.issue_data = result
+        self.data = result
       rescue => e
         raise CannotCreate, e.message
       end
 
-      # Public: The created issue's details
-      def issue_data
-        @issue_data || raise(NotYetCreated)
+      # Public: The created resource's details
+      def data
+        @data || raise(NotYetCreated)
       end
 
       # Public: The created issue's number
@@ -86,11 +86,26 @@ module Octopolo
         config.jira_url
       end
 
+      # Public: Rendering template for body property
+      #
+      # Returns Name of template file
+      def renderer_template
+        Renderer::ISSUE_BODY
+      end
+
+      # Public: Temporary file for body editing
+      #
+      # Returns Name of temporary file
+      def body_edit_temp_name
+        'octopolo_issue'
+      end
+
+
       # Public: The body (primary copy) of the issue
       #
       # Returns a String
       def body
-        output = Renderer.render Renderer::ISSUE_BODY, body_locals
+        output = Renderer.render renderer_template, body_locals
         output = edit_body(output) if options[:editor]
         output
       end
@@ -99,7 +114,7 @@ module Octopolo
         return body unless ENV['EDITOR']
 
         # Open the file, write the contents, and close it
-        tempfile = Tempfile.new(['octopolo_issue', '.md'])
+        tempfile = Tempfile.new([body_edit_temp_name, '.md'])
         tempfile.write(body)
         tempfile.close
 

--- a/lib/octopolo/github/issue_creator.rb
+++ b/lib/octopolo/github/issue_creator.rb
@@ -40,7 +40,8 @@ module Octopolo
       # Returns an array with the first element being the issue's
       # number, the second being a Mash of the response from GitHub's API
       def perform
-        result = GitHub.create_issue(repo_name, title, body)
+        # labels option cannot be null due to https://github.com/octokit/octokit.rb/pull/538
+        result = GitHub.create_issue(repo_name, title, body, labels: [])
         # capture the information
         self.number = result.number
         self.data = result

--- a/lib/octopolo/github/pull_request.rb
+++ b/lib/octopolo/github/pull_request.rb
@@ -1,20 +1,10 @@
+require_relative "issue"
 require_relative "../week"
 require "octokit"
 
 module Octopolo
   module GitHub
-    class PullRequest
-      attr_accessor :pull_request_data
-      attr_accessor :repo_name
-      attr_accessor :number
-
-      def initialize repo_name, number, pull_request_data = nil
-        raise MissingParameter if repo_name.nil? or number.nil?
-
-        self.repo_name = repo_name
-        self.number = number
-        self.pull_request_data = pull_request_data
-      end
+    class PullRequest < Issue
 
       # Public: All closed pull requests for a given repo
       #
@@ -42,33 +32,25 @@ module Octopolo
         # create via the API
         creator = PullRequestCreator.perform(repo_name, options)
         # wrap in our class
-        new repo_name, creator.number, creator.pull_request_data
+        new repo_name, creator.number, creator.data
       end
 
-      def pull_request_data
-        @pull_request_data ||= GitHub.pull_request(repo_name, number)
+      def data
+        @data ||= GitHub.pull_request(repo_name, number)
       rescue Octokit::NotFound
         raise NotFound
       end
 
-      def title
-        pull_request_data.title
-      end
-
-      def url
-        pull_request_data.html_url
-      end
-
       def branch
-        pull_request_data.head.ref
+        data.head.ref
       end
 
       def mergeable?
-        pull_request_data.mergeable
+        data.mergeable
       end
 
       def week
-        Week.parse pull_request_data.closed_at
+        Week.parse data.closed_at
       end
 
       def commenter_names
@@ -79,63 +61,10 @@ module Octopolo
         exclude_octopolo_user commits.map(&:author_name).uniq
       end
 
-      def exclude_octopolo_user(user_list)
-        user_list.reject{|u| GitHub.excluded_users.include?(u) }
-      end
-
-      def body
-        pull_request_data.body || ""
-      end
-
-      def external_urls
-        # extract http and https URLs from the body
-        URI.extract body, %w(http https)
-      end
-
-      def human_app_name
-        repo = repo_name.split("/").last
-        repo.split("_").map(&:capitalize).join(" ")
-      end
-
       def commits
         @commits ||= Commit.for_pull_request self
       end
 
-      def comments
-        @comments ||= GitHub.issue_comments(repo_name, number)
-      end
-
-      # Public: Add a comment to the pull request
-      #
-      # message - A String containing the desired comment body
-      def write_comment(message)
-        GitHub.add_comment repo_name, number, ":octocat: #{message}"
-      rescue Octokit::UnprocessableEntity => error
-        raise CommentFailed, "Unable to write the comment: '#{error.message}'"
-      end
-
-      # Public: Adds labels to a pull-request
-      #
-      # labels - label objects, can be a single label, an array of labels,
-      #          or a list of labels
-      def add_labels(*labels)
-        built_labels = Label.build_label_array(labels)
-        GitHub.add_labels_to_pull(repo_name, number, built_labels.map(&:name) )
-      end
-
-      # Public: Removes labels from a pull-request,
-      #
-      # labels - label objects, can be a single label, an array of labels,
-      #          or a list of labels
-      def remove_labels(*labels)
-        Label.build_label_array(labels).each do |built_label|
-          GitHub.remove_label(repo_name, number, built_label.name)
-        end
-      end
-
-      MissingParameter = Class.new StandardError
-      NotFound = Class.new StandardError
-      CommentFailed = Class.new StandardError
     end
   end
 end

--- a/lib/octopolo/github/pull_request.rb
+++ b/lib/octopolo/github/pull_request.rb
@@ -72,14 +72,14 @@ module Octopolo
       end
 
       def commenter_names
-        exlude_octopolo_user (comments.map{ |comment| GitHub::User.new(comment.user.login).author_name }.uniq - author_names)
+        exclude_octopolo_user (comments.map{ |comment| GitHub::User.new(comment.user.login).author_name }.uniq - author_names)
       end
 
       def author_names
-        exlude_octopolo_user commits.map(&:author_name).uniq
+        exclude_octopolo_user commits.map(&:author_name).uniq
       end
 
-      def exlude_octopolo_user(user_list)
+      def exclude_octopolo_user(user_list)
         user_list.reject{|u| GitHub.excluded_users.include?(u) }
       end
 

--- a/lib/octopolo/github/pull_request_creator.rb
+++ b/lib/octopolo/github/pull_request_creator.rb
@@ -1,16 +1,10 @@
+require_relative "issue_creator"
 require_relative "../renderer"
 require 'tempfile'
 
 module Octopolo
   module GitHub
-    class PullRequestCreator
-      include ConfigWrapper
-      # for instantiating the pull request creator
-      attr_accessor :repo_name
-      attr_accessor :options
-      # for caputuring the created pull request information
-      attr_accessor :number
-      attr_accessor :pull_request_data
+    class PullRequestCreator < IssueCreator
 
       # Public: Create a pull request for the given repo with the given options
       #
@@ -24,21 +18,6 @@ module Octopolo
         self.options = options
       end
 
-      # Public: Create a pull request for the given repo with the given options
-      #
-      # repo_name - Full name ("account/repo") of the repo in question
-      # options - Hash of pull request information
-      #   title: Title of the pull request
-      #   destination_branch: Which branch to merge into
-      #   source_branch: Which branch to be merged
-      #
-      # Returns the PullRequestCreator instance
-      def self.perform repo_name, options
-        new(repo_name, options).tap do |creator|
-          creator.perform
-        end
-      end
-
       # Public: Create the pull request
       #
       # Returns an array with the first element being the pull request's
@@ -47,19 +26,9 @@ module Octopolo
         result = GitHub.create_pull_request(repo_name, destination_branch, source_branch, title, body)
         # capture the information
         self.number = result.number
-        self.pull_request_data = result
+        self.data = result
       rescue => e
         raise CannotCreate, e.message
-      end
-
-      # Public: The created pull request's details
-      def pull_request_data
-        @pull_request_data || raise(NotYetCreated)
-      end
-
-      # Public: The created pull request's number
-      def number
-        @number || raise(NotYetCreated)
       end
 
       # Public: Branch to merge the pull request into
@@ -76,74 +45,21 @@ module Octopolo
         options[:source_branch] || raise(MissingAttribute)
       end
 
-      # Public: Title of the pull request
+      # Public: Rendering template for body property
       #
-      # Returns a String with the title
-      def title
-        options[:title] || raise(MissingAttribute)
+      # Returns Name of template file
+      def renderer_template
+        Renderer::PULL_REQUEST_BODY
       end
 
-      # Public: The Pivotal Tracker story IDs associated with the pull request
+
+      # Public: Temporary file for body editing
       #
-      # Returns an Array of Strings
-      def pivotal_ids
-        options[:pivotal_ids] || []
+      # Returns Name of temporary file
+      def body_edit_temp_name
+        'octopolo_pull_request'
       end
 
-      # Public: Jira Issue IDs associated with the pull request
-      #
-      # Returns an Array of Strings
-      def jira_ids
-        options[:jira_ids] || []
-      end
-
-      # Public: Jira Url associated with the pull request
-      #
-      # Returns Jira Url
-      def jira_url
-        config.jira_url
-      end
-
-      # Public: The body (primary copy) of the pull request
-      #
-      # Returns a String
-      def body
-        output = Renderer.render Renderer::PULL_REQUEST_BODY, body_locals
-        output = edit_body(output) if options[:editor]
-        output
-      end
-
-      def edit_body(body)
-        return body unless ENV['EDITOR']
-
-        # Open the file, write the contents, and close it
-        tempfile = Tempfile.new(['octopolo_pull_request', '.md'])
-        tempfile.write(body)
-        tempfile.close
-
-        # Allow the user to edit the file
-        system "#{ENV['EDITOR']} #{tempfile.path}"
-
-        # Reopen the file, read the contents, and delete it
-        tempfile.open
-        output = tempfile.read
-        tempfile.unlink
-
-        output
-      end
-
-      # Public: The local variables to pass into the template
-      def body_locals
-        {
-          pivotal_ids: pivotal_ids,
-          jira_ids: jira_ids,
-          jira_url: jira_url,
-        }
-      end
-
-      MissingAttribute = Class.new(StandardError)
-      NotYetCreated = Class.new(StandardError)
-      CannotCreate = Class.new(StandardError)
     end
   end
 end

--- a/lib/octopolo/github/pull_request_creator.rb
+++ b/lib/octopolo/github/pull_request_creator.rb
@@ -14,8 +14,7 @@ module Octopolo
       #   destination_branch: Which branch to merge into
       #   source_branch: Which branch to be merged
       def initialize repo_name, options
-        self.repo_name = repo_name
-        self.options = options
+        super(repo_name, options)
       end
 
       # Public: Create the pull request

--- a/lib/octopolo/renderer.rb
+++ b/lib/octopolo/renderer.rb
@@ -5,6 +5,7 @@ module Octopolo
   class Renderer
     # Constants for the template file names
     PULL_REQUEST_BODY = "pull_request_body"
+    ISSUE_BODY = "issue_body"
 
     # Public: Render a given ERB template
     #

--- a/lib/octopolo/scripts/issue.rb
+++ b/lib/octopolo/scripts/issue.rb
@@ -1,5 +1,7 @@
 require_relative "../scripts"
 require_relative "../github"
+require_relative "../github/issue"
+require_relative "../github/issue_creator"
 require_relative "../pivotal/story_commenter"
 require_relative "../jira/story_commenter"
 

--- a/lib/octopolo/scripts/issue.rb
+++ b/lib/octopolo/scripts/issue.rb
@@ -1,0 +1,138 @@
+require_relative "../scripts"
+require_relative "../github"
+require_relative "../pivotal/story_commenter"
+require_relative "../jira/story_commenter"
+
+module Octopolo
+  module Scripts
+    class Issue
+      include CLIWrapper
+      include ConfigWrapper
+      include GitWrapper
+
+      attr_accessor :title
+      attr_accessor :issue
+      attr_accessor :pivotal_ids
+      attr_accessor :jira_ids
+      attr_accessor :label
+      attr_accessor :options
+
+      def self.execute(options={})
+        new(options).execute
+      end
+
+      def initialize(options={})
+        @options = options
+      end
+
+      def execute
+        GitHub.connect do
+          ask_questionaire
+          create_issue
+          update_pivotal
+          update_jira
+          update_label
+          open_issue
+        end
+      end
+
+      # Private: Ask questions to create an issue
+      def ask_questionaire
+        announce
+        ask_title
+        ask_label
+        ask_pivotal_ids if config.use_pivotal_tracker
+        ask_jira_ids if config.use_jira
+      end
+      private :ask_questionaire
+
+      # Private: Announce to the user the branches the issue will reference
+      def announce
+        cli.say "Preparing an issue for #{config.github_repo}."
+      end
+      private :announce
+
+      # Private: Ask for a title for the issue
+      def ask_title
+        self.title = cli.prompt "Title:"
+      end
+      private :ask_title
+
+      # Private: Ask for a label for the issue
+      def ask_label
+        choices = Octopolo::GitHub::Label.get_names(label_choices).concat(["None"])
+        response = cli.ask(label_prompt, choices)
+        self.label = Hash[label_choices.map{|l| [l.name,l]}][response]
+      end
+      private :ask_label
+
+      # Private: Ask for a Pivotal Tracker story IDs
+      def ask_pivotal_ids
+        self.pivotal_ids = cli.prompt("Pivotal Tracker story ID(s):").split(/[\s,]+/)
+      end
+      private :ask_pivotal_ids
+
+      # Private: Ask for a Pivotal Tracker story IDs
+      def ask_jira_ids
+        self.jira_ids = cli.prompt("Jira story ID(s):").split(/[\s,]+/)
+      end
+      private :ask_pivotal_ids
+
+      # Private: Create the issue
+      #
+      # Returns a GitHub::Issue object
+      def create_issue
+        self.issue = GitHub::Issue.create config.github_repo, issue_attributes
+      end
+      private :create_issue
+
+      # Private: The attributes to send to create the issue
+      #
+      # Returns a Hash
+      def issue_attributes
+        {
+          title: title,
+          pivotal_ids: pivotal_ids,
+          jira_ids: jira_ids,
+          editor: options[:editor]
+        }
+      end
+      private :issue_attributes
+
+      # Private: Handle the newly created issue
+      def open_issue
+        cli.copy_to_clipboard issue.url
+        cli.open issue.url
+      end
+      private :open_issue
+
+      def label_prompt
+        'Label:'
+      end
+
+      def label_choices
+        Octopolo::GitHub::Label.all
+      end
+
+      def update_pivotal
+        pivotal_ids.each do |story_id|
+          Pivotal::StoryCommenter.new(story_id, issue.url).perform
+        end if pivotal_ids
+      end
+      private :update_pivotal
+
+      def update_jira
+        jira_ids.each do |story_id|
+          Jira::StoryCommenter.new(story_id, issue.url).perform
+        end if jira_ids
+      end
+      private :update_jira
+
+      def update_label
+        issue.add_labels(label) if label
+      end
+      private :update_label
+
+    end
+  end
+end

--- a/lib/octopolo/scripts/issue.rb
+++ b/lib/octopolo/scripts/issue.rb
@@ -34,7 +34,7 @@ module Octopolo
           update_pivotal
           update_jira
           update_label
-          open_issue
+          open_in_browser
         end
       end
 
@@ -102,11 +102,11 @@ module Octopolo
       protected :issue_attributes
 
       # Protected: Handle the newly created issue
-      def open_issue
+      def open_in_browser
         cli.copy_to_clipboard issue.url
         cli.open issue.url
       end
-      protected :open_issue
+      protected :open_in_browser
 
       def label_prompt
         'Label:'

--- a/lib/octopolo/scripts/issue.rb
+++ b/lib/octopolo/scripts/issue.rb
@@ -38,7 +38,7 @@ module Octopolo
         end
       end
 
-      # Private: Ask questions to create an issue
+      # Protected: Ask questions to create an issue
       def ask_questionaire
         announce
         ask_title
@@ -46,49 +46,49 @@ module Octopolo
         ask_pivotal_ids if config.use_pivotal_tracker
         ask_jira_ids if config.use_jira
       end
-      private :ask_questionaire
+      protected :ask_questionaire
 
-      # Private: Announce to the user the branches the issue will reference
+      # Protected: Announce to the user the branches the issue will reference
       def announce
         cli.say "Preparing an issue for #{config.github_repo}."
       end
-      private :announce
+      protected :announce
 
-      # Private: Ask for a title for the issue
+      # Protected: Ask for a title for the issue
       def ask_title
         self.title = cli.prompt "Title:"
       end
-      private :ask_title
+      protected :ask_title
 
-      # Private: Ask for a label for the issue
+      # Protected: Ask for a label for the issue
       def ask_label
         choices = Octopolo::GitHub::Label.get_names(label_choices).concat(["None"])
         response = cli.ask(label_prompt, choices)
         self.label = Hash[label_choices.map{|l| [l.name,l]}][response]
       end
-      private :ask_label
+      protected :ask_label
 
-      # Private: Ask for a Pivotal Tracker story IDs
+      # Protected: Ask for a Pivotal Tracker story IDs
       def ask_pivotal_ids
         self.pivotal_ids = cli.prompt("Pivotal Tracker story ID(s):").split(/[\s,]+/)
       end
-      private :ask_pivotal_ids
+      protected :ask_pivotal_ids
 
-      # Private: Ask for a Pivotal Tracker story IDs
+      # Protected: Ask for a Pivotal Tracker story IDs
       def ask_jira_ids
         self.jira_ids = cli.prompt("Jira story ID(s):").split(/[\s,]+/)
       end
-      private :ask_pivotal_ids
+      protected :ask_pivotal_ids
 
-      # Private: Create the issue
+      # Protected: Create the issue
       #
       # Returns a GitHub::Issue object
       def create_issue
         self.issue = GitHub::Issue.create config.github_repo, issue_attributes
       end
-      private :create_issue
+      protected :create_issue
 
-      # Private: The attributes to send to create the issue
+      # Protected: The attributes to send to create the issue
       #
       # Returns a Hash
       def issue_attributes
@@ -99,14 +99,14 @@ module Octopolo
           editor: options[:editor]
         }
       end
-      private :issue_attributes
+      protected :issue_attributes
 
-      # Private: Handle the newly created issue
+      # Protected: Handle the newly created issue
       def open_issue
         cli.copy_to_clipboard issue.url
         cli.open issue.url
       end
-      private :open_issue
+      protected :open_issue
 
       def label_prompt
         'Label:'
@@ -121,19 +121,19 @@ module Octopolo
           Pivotal::StoryCommenter.new(story_id, issue.url).perform
         end if pivotal_ids
       end
-      private :update_pivotal
+      protected :update_pivotal
 
       def update_jira
         jira_ids.each do |story_id|
           Jira::StoryCommenter.new(story_id, issue.url).perform
         end if jira_ids
       end
-      private :update_jira
+      protected :update_jira
 
       def update_label
         issue.add_labels(label) if label
       end
-      private :update_label
+      protected :update_label
 
     end
   end

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -1,4 +1,5 @@
 require_relative "../scripts"
+require_relative "../scripts/issue"
 require_relative "../github"
 require_relative "../pivotal/story_commenter"
 require_relative "../jira/story_commenter"

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -9,6 +9,8 @@ module Octopolo
       attr_accessor :pull_request
       attr_accessor :destination_branch
 
+      alias_method :issue, :pull_request
+
       def self.execute(destination_branch=nil, options={})
         new(destination_branch, options).execute
       end
@@ -16,10 +18,6 @@ module Octopolo
       def initialize(destination_branch=nil, options={})
         @destination_branch = destination_branch || default_destination_branch
         @options = options
-      end
-
-      def issue
-        pull_request
       end
 
       def default_destination_branch
@@ -33,7 +31,7 @@ module Octopolo
           update_pivotal
           update_jira
           update_label
-          open_pull_request
+          open_in_browser
         end
       end
 
@@ -83,13 +81,6 @@ module Octopolo
         }
       end
       private :pull_request_attributes
-
-      # Private: Handle the newly created pull request
-      def open_pull_request
-        cli.copy_to_clipboard pull_request.url
-        cli.open pull_request.url
-      end
-      private :open_pull_request
 
     end
   end

--- a/lib/octopolo/templates/issue_body.erb
+++ b/lib/octopolo/templates/issue_body.erb
@@ -1,0 +1,22 @@
+<%= description %>
+
+Deploy Plan
+-----------
+How will the changes to resolve this issue be deployed.
+
+Rollback Plan
+-------------
+How would the changes applied to resolve this issue be reverted?
+
+URLs
+----
+<% pivotal_ids.each do |pivotal_id| -%>
+* [pivotal tracker story <%= pivotal_id %>](https://www.pivotaltracker.com/story/show/<%= pivotal_id %>)
+<% end -%>
+<% jira_ids.each do |jira_id| -%>
+* [Jira issue <%= jira_id %>](<%= jira_url %>/browse/<%= jira_id %>)
+<% end -%>
+
+QA Plan
+-------
+Provide a detailed QA plan, or other developers will retain the right to mock you mercilessly.

--- a/lib/octopolo/templates/issue_body.erb
+++ b/lib/octopolo/templates/issue_body.erb
@@ -2,11 +2,11 @@
 
 Deploy Plan
 -----------
-How will the changes to resolve this issue be deployed.
+Describe how this change will be deployed.
 
 Rollback Plan
 -------------
-How would the changes applied to resolve this issue be reverted?
+Describe how this change can be rolled back.
 
 URLs
 ----

--- a/octopolo.gemspec
+++ b/octopolo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rake'
   gem.add_dependency 'gli', '~> 2.13'
   gem.add_dependency 'hashie', '~> 1.2'
-  gem.add_dependency 'octokit', '~> 3.8.0'
+  gem.add_dependency 'octokit', '~> 2.7.1'
   gem.add_dependency 'highline', '~> 1.6'
   gem.add_dependency 'pivotal-tracker', '~> 0.5'
   gem.add_dependency 'jiralicious'

--- a/octopolo.gemspec
+++ b/octopolo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rake'
   gem.add_dependency 'gli', '~> 2.13'
   gem.add_dependency 'hashie', '~> 1.2'
-  gem.add_dependency 'octokit', '~> 2.7.1'
+  gem.add_dependency 'octokit', '~> 3.8.0'
   gem.add_dependency 'highline', '~> 1.6'
   gem.add_dependency 'pivotal-tracker', '~> 0.5'
   gem.add_dependency 'jiralicious'

--- a/spec/octopolo/github/issue_creator_spec.rb
+++ b/spec/octopolo/github/issue_creator_spec.rb
@@ -32,7 +32,7 @@ module Octopolo
       end
 
       context "#perform" do
-        let(:issue_data) { stub(:mash, number: 123) }
+        let(:data) { stub(:mash, number: 123) }
 
         before do
           creator.stub({
@@ -42,10 +42,10 @@ module Octopolo
         end
 
         it "generates the issue with the given details and retains the information" do
-          GitHub.should_receive(:create_issue).with(repo_name, title, body) { issue_data }
-          creator.perform.should == issue_data
-          creator.number.should == issue_data.number
-          creator.issue_data.should == issue_data
+          GitHub.should_receive(:create_issue).with(repo_name, title, body) { data }
+          creator.perform.should == data
+          creator.number.should == data.number
+          creator.data.should == data
         end
 
         it "raises CannotCreate if any exception occurs" do
@@ -68,17 +68,17 @@ module Octopolo
         end
       end
 
-      context "#issue_data" do
-        let(:details) { stub(:issue_data) }
+      context "#data" do
+        let(:details) { stub(:data) }
 
         it "returns the stored issue details" do
-          creator.issue_data = details
-          creator.issue_data.should == details
+          creator.data = details
+          creator.data.should == details
         end
 
         it "raises an exception if no information has been captured yet" do
-          creator.issue_data = nil
-          expect { creator.issue_data }.to raise_error(IssueCreator::NotYetCreated)
+          creator.data = nil
+          expect { creator.data }.to raise_error(IssueCreator::NotYetCreated)
         end
       end
 

--- a/spec/octopolo/github/issue_creator_spec.rb
+++ b/spec/octopolo/github/issue_creator_spec.rb
@@ -42,7 +42,7 @@ module Octopolo
         end
 
         it "generates the issue with the given details and retains the information" do
-          GitHub.should_receive(:create_issue).with(repo_name, title, body) { data }
+          GitHub.should_receive(:create_issue).with(repo_name, title, body, labels: []) { data }
           creator.perform.should == data
           creator.number.should == data.number
           creator.data.should == data

--- a/spec/octopolo/github/issue_creator_spec.rb
+++ b/spec/octopolo/github/issue_creator_spec.rb
@@ -1,0 +1,217 @@
+require "spec_helper"
+require_relative "../../../lib/octopolo/github/issue_creator"
+
+module Octopolo
+  module GitHub
+    describe IssueCreator do
+      let(:creator) { IssueCreator.new repo_name, options }
+      let(:repo_name) { "foo/bar" }
+      let(:options) { {} }
+      let(:title) { "title" }
+      let(:body) { "body" }
+      let(:pivotal_ids) { %w(123 456) }
+      let(:jira_ids) { %w(123 456) }
+      let(:jira_url) { "https://example-jira.com" }
+
+      context ".perform repo_name, options" do
+        let(:creator) { stub }
+
+        it "instantiates a creator and perfoms it" do
+          IssueCreator.should_receive(:new).with(repo_name, options) { creator }
+          creator.should_receive(:perform)
+          IssueCreator.perform(repo_name, options).should == creator
+        end
+      end
+
+      context ".new repo_name, options" do
+        it "remembers the repo name and options" do
+          creator = IssueCreator.new repo_name, options
+          creator.repo_name.should == repo_name
+          creator.options.should == options
+        end
+      end
+
+      context "#perform" do
+        let(:issue_data) { stub(:mash, number: 123) }
+
+        before do
+          creator.stub({
+            title: title,
+            body: body,
+          })
+        end
+
+        it "generates the issue with the given details and retains the information" do
+          GitHub.should_receive(:create_issue).with(repo_name, title, body) { issue_data }
+          creator.perform.should == issue_data
+          creator.number.should == issue_data.number
+          creator.issue_data.should == issue_data
+        end
+
+        it "raises CannotCreate if any exception occurs" do
+          GitHub.should_receive(:create_issue).and_raise(Octokit::UnprocessableEntity)
+          expect { creator.perform }.to raise_error(IssueCreator::CannotCreate)
+        end
+      end
+
+      context "#number" do
+        let(:number) { 123 }
+
+        it "returns the stored issue number" do
+          creator.number = number
+          creator.number.should == number
+        end
+
+        it "raises an exception if no issue has been created yet" do
+          creator.number = nil
+          expect { creator.number }.to raise_error(IssueCreator::NotYetCreated)
+        end
+      end
+
+      context "#issue_data" do
+        let(:details) { stub(:issue_data) }
+
+        it "returns the stored issue details" do
+          creator.issue_data = details
+          creator.issue_data.should == details
+        end
+
+        it "raises an exception if no information has been captured yet" do
+          creator.issue_data = nil
+          expect { creator.issue_data }.to raise_error(IssueCreator::NotYetCreated)
+        end
+      end
+
+      context "#title" do
+        context "having the option set" do
+          before { creator.options[:title] = title }
+
+          it "fetches from the options" do
+            creator.title.should == title
+          end
+        end
+
+        it "raises an exception if it's missing" do
+          creator.options[:title] = nil
+          expect { creator.title }.to raise_error(IssueCreator::MissingAttribute)
+        end
+      end
+
+      context "#pivotal_ids" do
+        it "fetches from the options" do
+          creator.options[:pivotal_ids] = pivotal_ids
+          creator.pivotal_ids.should == pivotal_ids
+        end
+
+        it "defaults to an empty array if it's missing" do
+          creator.options[:pivotal_ids] = nil
+          creator.pivotal_ids.should == []
+        end
+      end
+
+      context "#body_locals" do
+        let(:urls) { %w(link1 link2) }
+
+        before do
+          creator.stub({
+            pivotal_ids: pivotal_ids,
+            jira_ids: jira_ids,
+            jira_url: jira_url,
+          })
+        end
+        it "includes the necessary keys to render the template" do
+          creator.body_locals[:pivotal_ids].should == creator.pivotal_ids
+          creator.body_locals[:jira_ids].should == creator.jira_ids
+          creator.body_locals[:jira_url].should == creator.jira_url
+        end
+      end
+
+      context "#edit_body" do
+        let(:path) { stub(:path) }
+        let(:body) { stub(:string) }
+        let(:tempfile) { stub(:tempfile) }
+        let(:edited_body) { stub(:edited_body) }
+
+        before do
+          Tempfile.stub(:new) { tempfile }
+          tempfile.stub(path: path, write: nil, read: edited_body, unlink: nil, close: nil, open: nil)
+          creator.stub(:system)
+        end
+
+        context "without the $EDITOR env var set" do
+          before do
+            stub_const('ENV', {'EDITOR' => nil})
+          end
+
+          it "returns the un-edited output" do
+            creator.edit_body(body).should == body
+          end
+        end
+
+        context "with the $EDITOR env set" do
+
+          before do
+            stub_const('ENV', {'EDITOR' => 'vim'})
+          end
+
+          it "creates a tempfile, write default contents, and close it" do
+            Tempfile.should_receive(:new).with(['octopolo_issue', '.md']) { tempfile }
+            tempfile.should_receive(:write).with(body)
+            tempfile.should_receive(:close)
+            creator.edit_body body
+          end
+
+          it "edits the tempfile with the $EDITOR" do
+            tempfile.should_receive(:path) { path }
+            creator.should_receive(:system).with("vim #{path}")
+            creator.edit_body body
+          end
+
+          it "reopens the file, gets the contents, and deletes the temp file" do
+            tempfile.should_receive(:open)
+            tempfile.should_receive(:read) { edited_body }
+            tempfile.should_receive(:unlink)
+            creator.edit_body body
+          end
+
+          it "returns the user edited output" do
+            creator.edit_body(body).should == edited_body
+          end
+        end
+      end
+
+      context "#body" do
+        let(:locals) { stub(:hash) }
+        let(:output) { stub(:string) }
+
+        before do
+          creator.stub({
+            body_locals: locals,
+          })
+        end
+
+        it "renders the body template with the body locals" do
+          Renderer.should_receive(:render).with(Renderer::ISSUE_BODY, locals) { output }
+          creator.body.should == output
+        end
+
+        context "when the editor option is set" do
+          let(:edited_output) { stub(:output) }
+
+          before do
+            creator.stub({
+              body_locals: locals,
+              options: { editor: true }
+            })
+          end
+
+          it "calls the edit_body method" do
+            Renderer.should_receive(:render).with(Renderer::ISSUE_BODY, locals) { output }
+            creator.should_receive(:edit_body).with(output) { edited_output }
+            creator.body.should == edited_output
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/octopolo/github/issue_spec.rb
+++ b/spec/octopolo/github/issue_spec.rb
@@ -20,7 +20,7 @@ module Octopolo
 
         it "optionally accepts the github data" do
           i = Issue.new repo_name, issue_number, octo
-          i.issue_data.should == octo
+          i.data.should == octo
         end
 
         it "fails if not given a repo name" do
@@ -32,23 +32,23 @@ module Octopolo
         end
       end
 
-      context "#issue_data" do
+      context "#data" do
         let(:issue) { Issue.new repo_name, issue_number }
 
         it "fetches the details from GitHub" do
           GitHub.should_receive(:issue).with(issue.repo_name, issue.number) { octo }
-          issue.issue_data.should == octo
+          issue.data.should == octo
         end
 
         it "catches the information" do
           GitHub.should_receive(:issue).once { octo }
-          issue.issue_data
-          issue.issue_data
+          issue.data
+          issue.data
         end
 
         it "fails if given invalid information" do
           GitHub.should_receive(:issue).and_raise(Octokit::NotFound)
-          expect { issue.issue_data }.to raise_error(Issue::NotFound)
+          expect { issue.data }.to raise_error(Issue::NotFound)
         end
       end
 
@@ -56,7 +56,7 @@ module Octopolo
         let(:issue) { Issue.new repo_name, issue_number }
 
         before do
-          issue.stub(issue_data: octo)
+          issue.stub(data: octo)
         end
 
         context "#title" do
@@ -100,8 +100,8 @@ module Octopolo
           let(:users) { ["anfleene", "tst-octopolo"] }
 
           it "excludes the github octopolo users" do
-            issue.exlude_octopolo_user(users).should_not include("tst-octopolo")
-            issue.exlude_octopolo_user(users).should include("anfleene")
+            issue.exclude_octopolo_user(users).should_not include("tst-octopolo")
+            issue.exclude_octopolo_user(users).should include("anfleene")
           end
         end
 
@@ -187,13 +187,13 @@ module Octopolo
       context ".create repo_name, options" do
         let(:options) { stub(:hash) }
         let(:number) { stub(:integer) }
-        let(:issue_data) { stub(:issue_data)}
-        let(:creator) { stub(:issue_creator, number: number, issue_data: issue_data)}
+        let(:data) { stub(:data)}
+        let(:creator) { stub(:issue_creator, number: number, data: data)}
         let(:issue) { stub(:issue) }
 
         it "passes on to IssueCreator and returns a new Issue" do
           IssueCreator.should_receive(:perform).with(repo_name, options) { creator }
-          Issue.should_receive(:new).with(repo_name, number, issue_data) { issue }
+          Issue.should_receive(:new).with(repo_name, number, data) { issue }
           Issue.create(repo_name, options).should == issue
         end
       end

--- a/spec/octopolo/github/issue_spec.rb
+++ b/spec/octopolo/github/issue_spec.rb
@@ -1,0 +1,243 @@
+require "spec_helper"
+require_relative "../../../lib/octopolo/github/issue"
+require_relative "../../../lib/octopolo/github/issue_creator"
+
+module Octopolo
+  module GitHub
+    describe Issue do
+      let(:repo_name) { "account/repo" }
+      let(:issue_number) { 7 }
+      let(:issue_hash) { stub }
+      let(:comments) { stub }
+      let(:octo) { stub }
+
+      context ".new" do
+        it "remembers the issue identifiers" do
+          i = Issue.new repo_name, issue_number
+          i.repo_name.should == repo_name
+          i.number.should == issue_number
+        end
+
+        it "optionally accepts the github data" do
+          i = Issue.new repo_name, issue_number, octo
+          i.issue_data.should == octo
+        end
+
+        it "fails if not given a repo name" do
+          expect { Issue.new nil, issue_number }.to raise_error(Issue::MissingParameter)
+        end
+
+        it "fails if not given a issue number" do
+          expect { Issue.new repo_name, nil }.to raise_error(Issue::MissingParameter)
+        end
+      end
+
+      context "#issue_data" do
+        let(:issue) { Issue.new repo_name, issue_number }
+
+        it "fetches the details from GitHub" do
+          GitHub.should_receive(:issue).with(issue.repo_name, issue.number) { octo }
+          issue.issue_data.should == octo
+        end
+
+        it "catches the information" do
+          GitHub.should_receive(:issue).once { octo }
+          issue.issue_data
+          issue.issue_data
+        end
+
+        it "fails if given invalid information" do
+          GitHub.should_receive(:issue).and_raise(Octokit::NotFound)
+          expect { issue.issue_data }.to raise_error(Issue::NotFound)
+        end
+      end
+
+      context "fetching its attributes from Octokit" do
+        let(:issue) { Issue.new repo_name, issue_number }
+
+        before do
+          issue.stub(issue_data: octo)
+        end
+
+        context "#title" do
+          let(:octo) { stub(title: "the title") }
+
+          it "retrieves from the github data" do
+            issue.title.should == octo.title
+          end
+        end
+
+        context "#comments" do
+          it "fetches through octokit" do
+            GitHub.should_receive(:issue_comments).with(issue.repo_name, issue.number) { comments }
+            issue.comments.should == comments
+          end
+
+          it "caches the result" do
+            GitHub.should_receive(:issue_comments).once { comments }
+            issue.comments
+            issue.comments
+          end
+        end
+
+        context "#commenter_names" do
+          let(:comment1) { stub(user: stub(login: "pbyrne")) }
+          let(:comment2) { stub(user: stub(login: "anfleene")) }
+
+          before do
+            issue.stub(comments: [comment1, comment2])
+          end
+
+          it "returns only unique values" do
+            # make it same commenter
+            comment2.user.stub(login: comment1.user.login)
+            names = issue.commenter_names
+            names.size.should == 1
+          end
+        end
+
+        context "#without_octopolo_users" do
+          let(:users) { ["anfleene", "tst-octopolo"] }
+
+          it "excludes the github octopolo users" do
+            issue.exlude_octopolo_user(users).should_not include("tst-octopolo")
+            issue.exlude_octopolo_user(users).should include("anfleene")
+          end
+        end
+
+        context "#url" do
+          let(:octo) { stub(html_url: "http://example.com") }
+
+          it "retrieves from the github data" do
+            issue.url.should == octo.html_url
+          end
+        end
+
+        context "#external_urls" do
+          # nicked from https://github.com/tstmedia/ngin/issue/1151
+          let(:body) do
+            <<-END
+              http://thedesk.tstmedia.com/admin.php?pg=request&reqid=44690 - verified
+              http://thedesk.tstmedia.com/admin.php?pg=request&reqid=44693 - verified
+
+                development_ftp_server: ftp.tstmedia.com
+                development_username: startribuneftptest@ftp.tstmedia.com
+                development_password: JUm1kU7STYt0
+              http://www.ngin.com.stage.ngin-staging.com/api/volleyball/stats/summaries?id=68382&gender=girls&tst_test=1&date=8/24/2012
+            END
+          end
+
+          before do
+            issue.stub(body: body)
+          end
+
+          it "parses from the body" do
+            urls = issue.external_urls
+            urls.size.should == 3
+            urls.should include "http://thedesk.tstmedia.com/admin.php?pg=request&reqid=44690"
+            urls.should include "http://thedesk.tstmedia.com/admin.php?pg=request&reqid=44693"
+            urls.should include "http://www.ngin.com.stage.ngin-staging.com/api/volleyball/stats/summaries?id=68382&gender=girls&tst_test=1&date=8/24/2012"
+          end
+        end
+
+        context "#body" do
+          let(:octo) { stub(body: "asdf") }
+
+          it "retrieves from the github data" do
+            issue.body.should == octo.body
+          end
+
+          it "returns an empty string if the GitHub data has no body" do
+            octo.stub(body: nil)
+            issue.body.should == ""
+          end
+        end
+      end
+
+      context "#human_app_name" do
+        let(:repo_name) { "account_name/repo_name" }
+        let(:issue) { Issue.new repo_name, issue_number }
+
+        it "infers from the repo_name" do
+          issue.repo_name = "account/foo"
+          issue.human_app_name.should == "Foo"
+          issue.repo_name = "account/foo_bar"
+          issue.human_app_name.should == "Foo Bar"
+        end
+      end
+
+      context "#write_comment(message)" do
+        let(:issue) { Issue.new repo_name, issue_number }
+        let(:message) { "Test message" }
+        let(:error) { Octokit::UnprocessableEntity.new }
+
+        it "creates the message through octokit" do
+          GitHub.should_receive(:add_comment).with(issue.repo_name, issue.number, ":octocat: #{message}")
+
+          issue.write_comment message
+        end
+
+        it "raises CommentFailed if an exception occurs" do
+          GitHub.should_receive(:add_comment).and_raise(error)
+
+          expect { issue.write_comment message }.to raise_error(Issue::CommentFailed, "Unable to write the comment: '#{error.message}'")
+        end
+      end
+
+      context ".create repo_name, options" do
+        let(:options) { stub(:hash) }
+        let(:number) { stub(:integer) }
+        let(:issue_data) { stub(:issue_data)}
+        let(:creator) { stub(:issue_creator, number: number, issue_data: issue_data)}
+        let(:issue) { stub(:issue) }
+
+        it "passes on to IssueCreator and returns a new Issue" do
+          IssueCreator.should_receive(:perform).with(repo_name, options) { creator }
+          Issue.should_receive(:new).with(repo_name, number, issue_data) { issue }
+          Issue.create(repo_name, options).should == issue
+        end
+      end
+
+      context "labeling" do
+        let(:label1) { Label.new(name: "low-risk", color: "343434") }
+        let(:label2) { Label.new(name: "high-risk", color: '565656') }
+        let(:issue) { Issue.new repo_name, issue_number }
+
+        context "#add_labels" do
+          it "sends the correct arguments to add_labels_to_issue for multiple labels" do
+            allow(Label).to receive(:build_label_array) {[label1,label2]}
+            expect(GitHub).to receive(:add_labels_to_issue).with(repo_name, issue_number, ["low-risk","high-risk"])
+            issue.add_labels([label1, label2])
+          end
+
+          it "sends the correct arguments to add_labels_to_issue for a single label" do
+            allow(Label).to receive(:build_label_array) {[label1]}
+            expect(GitHub).to receive(:add_labels_to_issue).with(repo_name, issue_number, ["low-risk"])
+            issue.add_labels(label1)
+          end
+        end
+
+        context "#remove_from_issue" do
+
+          it "sends the correct arguments to remove_label" do
+            allow(Label).to receive(:build_label_array) {[label1]}
+            expect(GitHub).to receive(:remove_label).with(repo_name, issue_number, "low-risk")
+            issue.remove_labels(label1)
+          end
+
+          it "calls remove_label only once" do
+            allow(Label).to receive(:build_label_array) {[label1]}
+            expect(GitHub).to receive(:remove_label).once
+            issue.remove_labels(label1)
+          end
+
+          it "calls remove_label twice" do
+            allow(Label).to receive(:build_label_array) {[label1, label2]}
+            expect(GitHub).to receive(:remove_label).twice
+            issue.remove_labels([label1,label2])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/octopolo/github/pull_request_creator_spec.rb
+++ b/spec/octopolo/github/pull_request_creator_spec.rb
@@ -34,7 +34,7 @@ module Octopolo
       end
 
       context "#perform" do
-        let(:pull_request_data) { stub(:mash, number: 123) }
+        let(:data) { stub(:mash, number: 123) }
 
         before do
           creator.stub({
@@ -46,10 +46,10 @@ module Octopolo
         end
 
         it "generates the pull request with the given details and retains the information" do
-          GitHub.should_receive(:create_pull_request).with(repo_name, destination_branch, source_branch, title, body) { pull_request_data }
-          creator.perform.should == pull_request_data
-          creator.number.should == pull_request_data.number
-          creator.pull_request_data.should == pull_request_data
+          GitHub.should_receive(:create_pull_request).with(repo_name, destination_branch, source_branch, title, body) { data }
+          creator.perform.should == data
+          creator.number.should == data.number
+          creator.data.should == data
         end
 
         it "raises CannotCreate if any exception occurs" do
@@ -72,17 +72,17 @@ module Octopolo
         end
       end
 
-      context "#pull_request_data" do
-        let(:details) { stub(:pull_request_data) }
+      context "#data" do
+        let(:details) { stub(:data) }
 
         it "returns the stored pull request details" do
-          creator.pull_request_data = details
-          creator.pull_request_data.should == details
+          creator.data = details
+          creator.data.should == details
         end
 
         it "raises an exception if no information has been captured yet" do
-          creator.pull_request_data = nil
-          expect { creator.pull_request_data }.to raise_error(PullRequestCreator::NotYetCreated)
+          creator.data = nil
+          expect { creator.data }.to raise_error(PullRequestCreator::NotYetCreated)
         end
       end
 

--- a/spec/octopolo/github/pull_request_spec.rb
+++ b/spec/octopolo/github/pull_request_spec.rb
@@ -20,7 +20,7 @@ module Octopolo
 
         it "optionally accepts the github data" do
           pr = PullRequest.new repo_name, pr_number, octo
-          pr.pull_request_data.should == octo
+          pr.data.should == octo
         end
 
         it "fails if not given a repo name" do
@@ -32,23 +32,23 @@ module Octopolo
         end
       end
 
-      context "#pull_request_data" do
+      context "#data" do
         let(:pull) { PullRequest.new repo_name, pr_number }
 
         it "fetches the details from GitHub" do
           GitHub.should_receive(:pull_request).with(pull.repo_name, pull.number) { octo }
-          pull.pull_request_data.should == octo
+          pull.data.should == octo
         end
 
         it "catches the information" do
           GitHub.should_receive(:pull_request).once { octo }
-          pull.pull_request_data
-          pull.pull_request_data
+          pull.data
+          pull.data
         end
 
         it "fails if given invalid information" do
           GitHub.should_receive(:pull_request).and_raise(Octokit::NotFound)
-          expect { pull.pull_request_data }.to raise_error(PullRequest::NotFound)
+          expect { pull.data }.to raise_error(PullRequest::NotFound)
         end
       end
 
@@ -56,7 +56,7 @@ module Octopolo
         let(:pull) { PullRequest.new repo_name, pr_number }
 
         before do
-          pull.stub(pull_request_data: octo)
+          pull.stub(data: octo)
         end
 
         context "#title" do
@@ -276,13 +276,13 @@ module Octopolo
       context ".create repo_name, options" do
         let(:options) { stub(:hash) }
         let(:number) { stub(:integer) }
-        let(:pull_request_data) { stub(:pull_request_data)}
-        let(:creator) { stub(:pull_request_creator, number: number, pull_request_data: pull_request_data)}
+        let(:data) { stub(:data)}
+        let(:creator) { stub(:pull_request_creator, number: number, data: data)}
         let(:pull_request) { stub(:pull_request) }
 
         it "passes on to PullRequestCreator and returns a new PullRequest" do
           PullRequestCreator.should_receive(:perform).with(repo_name, options) { creator }
-          PullRequest.should_receive(:new).with(repo_name, number, pull_request_data) { pull_request }
+          PullRequest.should_receive(:new).with(repo_name, number, data) { pull_request }
           PullRequest.create(repo_name, options).should == pull_request
         end
       end
@@ -295,13 +295,13 @@ module Octopolo
         context "#add_labels" do
           it "sends the correct arguments to add_labels_to_pull for multiple labels" do
             allow(Label).to receive(:build_label_array) {[label1,label2]}
-            expect(GitHub).to receive(:add_labels_to_pull).with(repo_name, pr_number, ["low-risk","high-risk"])
+            expect(GitHub).to receive(:add_labels_to_issue).with(repo_name, pr_number, ["low-risk","high-risk"])
             pull_request.add_labels([label1, label2])
           end
 
           it "sends the correct arguments to add_labels_to_pull for a single label" do
             allow(Label).to receive(:build_label_array) {[label1]}
-            expect(GitHub).to receive(:add_labels_to_pull).with(repo_name, pr_number, ["low-risk"])
+            expect(GitHub).to receive(:add_labels_to_issue).with(repo_name, pr_number, ["low-risk"])
             pull_request.add_labels(label1)
           end
         end

--- a/spec/octopolo/github/pull_request_spec.rb
+++ b/spec/octopolo/github/pull_request_spec.rb
@@ -130,11 +130,11 @@ module Octopolo
 
           before do
             pull.stub(comments: [comment1, comment2], author_names: [])
+            GitHub::User.stub(:new).with("pbyrne").and_return(stub(:author_name => "pbyrne"))
+            GitHub::User.stub(:new).with("anfleene").and_return(stub(:author_name => "anfleene"))
           end
 
           it "returns the names of the commit authors" do
-            GitHub.stub(:user).with("pbyrne").and_return(Hashie::Mash.new(:name => "pbyrne"))
-            GitHub.stub(:user).with("anfleene").and_return(Hashie::Mash.new(:name => "anfleene"))
             names = pull.commenter_names
             names.should_not be_empty
             names.size.should == 2
@@ -160,8 +160,8 @@ module Octopolo
           let(:users) { ["anfleene", "tst-octopolo"] }
 
           it "excludes the github octopolo users" do
-            pull.exlude_octopolo_user(users).should_not include("tst-octopolo")
-            pull.exlude_octopolo_user(users).should include("anfleene")
+            pull.exclude_octopolo_user(users).should_not include("tst-octopolo")
+            pull.exclude_octopolo_user(users).should include("anfleene")
           end
         end
 

--- a/spec/octopolo/github_spec.rb
+++ b/spec/octopolo/github_spec.rb
@@ -54,6 +54,14 @@ module Octopolo
         end
       end
 
+      context ".issue *args" do
+        it "sends onto the client wrapper" do
+          client.should_receive(:issue).with("a", "b") { data }
+          result = GitHub.issue("a", "b")
+          result.should == data
+        end
+      end
+
       context ".pull_request_commits *args" do
         it "sends onto the client wrapper" do
           client.should_receive(:pull_request_commits).with("a", "b") { data }
@@ -93,6 +101,13 @@ module Octopolo
         it "sends the pull request to the API" do
           client.should_receive(:create_pull_request).with("repo", "destination_branch", "source_branch", "title", "body") { data }
           GitHub.create_pull_request("repo", "destination_branch", "source_branch", "title", "body").should == data
+        end
+      end
+
+      context ".create_issue" do
+        it "sends the issue to the API" do
+          client.should_receive(:create_issue).with("repo", "title", "body") { data }
+          GitHub.create_issue("repo", "title", "body").should == data
         end
       end
 

--- a/spec/octopolo/scripts/issue_spec.rb
+++ b/spec/octopolo/scripts/issue_spec.rb
@@ -1,0 +1,233 @@
+require "spec_helper"
+require_relative "../../../lib/octopolo/scripts/issue"
+require_relative "../../../lib/octopolo/github/issue"
+
+module Octopolo
+  module Scripts
+    describe Issue do
+      let(:config) do
+        stub(:config, {
+          deploy_branch: "production",
+          github_repo: "tstmedia/foo",
+          use_pivotal_tracker: true,
+          use_jira: true
+        })
+      end
+      let(:cli) { stub(:cli) }
+      let(:git) { stub(:Git) }
+      let(:issue_url) { "http://github.com/tstmedia/octopolo/issues/0" }
+      let(:issue) { stub(:issue) }
+
+      subject { Issue.new }
+
+      before do
+        Issue.any_instance.stub({
+          :cli => cli,
+          :config => config,
+          :git => git
+        })
+      end
+
+      context "#new" do
+        it "accepts options" do
+          expect(Issue.new(:foo => 'bar').options).to eq(:foo => 'bar')
+        end
+      end
+
+      context "#execute" do
+        it "if connected to GitHub, asks some questions, creates the issue, and opens it" do
+          GitHub.should_receive(:connect).and_yield
+          expect(subject).to receive(:ask_questionaire)
+          expect(subject).to receive(:create_issue)
+          expect(subject).to receive(:update_pivotal)
+          expect(subject).to receive(:update_jira)
+          expect(subject).to receive(:update_label)
+          expect(subject).to receive(:open_issue)
+
+          subject.execute
+        end
+
+        it "if not connected to GitHub, does nothing" do
+          GitHub.should_receive(:connect) # and not yield, no github credentials
+          expect { subject.execute }.to_not raise_error
+        end
+      end
+
+      context "#ask_questionaire" do
+        it "asks appropriate questions to create a issue" do
+          expect(subject).to receive(:announce)
+          expect(subject).to receive(:ask_title)
+          expect(subject).to receive(:ask_pivotal_ids)
+          expect(subject).to receive(:ask_jira_ids)
+          expect(subject).to receive(:ask_label)
+
+          subject.send(:ask_questionaire)
+        end
+      end
+
+      context "#announce" do
+        it "displays information about the issue to be created" do
+          cli.should_receive(:say).with("Preparing an issue for #{config.github_repo}.")
+          subject.send(:announce)
+        end
+      end
+
+      context "#ask_title" do
+        let(:title) { "title" }
+
+        it "asks for and captures a title for the issue" do
+          cli.should_receive(:prompt).with("Title:") { title }
+          subject.send(:ask_title)
+          expect(subject.title).to eq(title)
+        end
+      end
+
+      context "#ask_label" do
+        let(:label1) {Octopolo::GitHub::Label.new(name: "low-risk", color: '151515')}
+        let(:label2) {Octopolo::GitHub::Label.new(name: "high-risk", color: '151515')}
+        let(:choices) {["low-risk","high-risk","None"]}
+
+        it "asks for and capture a label" do
+          allow(Octopolo::GitHub::Label).to receive(:all) {[label1,label2]}
+          expect(cli).to receive(:ask).with("Label:", choices)
+          subject.send(:ask_label)
+        end
+
+        it "asks for a label" do
+          allow(Octopolo::GitHub::Label).to receive(:all) {[label1,label2]}
+          allow(Octopolo::GitHub::Label).to receive(:get_names) {choices}
+          allow(cli).to receive(:ask) {"low-risk"}
+          expect(subject.send(:ask_label)).to eq(label1)
+        end
+      end
+
+      context "#ask_pivotal_ids" do
+        let(:ids_with_whitespace) { "123 456" }
+        let(:ids_with_commas) { "234, 567" }
+
+        it "asks for and captures IDs for related pivotal tasks" do
+          cli.should_receive(:prompt).with("Pivotal Tracker story ID(s):") { ids_with_whitespace }
+          subject.send(:ask_pivotal_ids)
+          expect(subject.pivotal_ids).to eq(%w(123 456))
+        end
+
+        it "asks for and captures IDs with commas" do
+          cli.should_receive(:prompt).with("Pivotal Tracker story ID(s):") { ids_with_commas }
+          subject.send(:ask_pivotal_ids)
+          expect(subject.pivotal_ids).to eq(%w(234 567))
+        end
+
+        it "sets to an empty array if not provided an ansswer" do
+          cli.should_receive(:prompt).with("Pivotal Tracker story ID(s):") { "" }
+          subject.send(:ask_pivotal_ids)
+          expect(subject.pivotal_ids).to eq([])
+        end
+      end
+
+      context "#create_issue" do
+        let(:attributes) { stub(:hash) }
+
+        before do
+          subject.stub(:issue_attributes) { attributes }
+        end
+
+        it "creates and stores the issue" do
+          GitHub::Issue.should_receive(:create).with(config.github_repo, attributes) { issue }
+          subject.send(:create_issue)
+          expect(subject.issue).to eq(issue)
+        end
+      end
+
+      context "#issue_attributes" do
+        before do
+          subject.title = "title"
+          subject.pivotal_ids = %w(123)
+        end
+
+        it "combines the anssers with a handful of deault values" do
+          subject.send(:issue_attributes).should == {
+            title: subject.title,
+            pivotal_ids: subject.pivotal_ids,
+            jira_ids: subject.jira_ids,
+            editor: nil
+          }
+        end
+      end
+
+      context "#label_choices" do
+        let(:label1) { Octopolo::GitHub::Label.new(name: "low-risk", color: '151515') }
+        let(:label2) { Octopolo::GitHub::Label.new(name: "high-risk", color: '151515') }
+        let(:github_labels) { [label1, label2] }
+
+        it "returns the labels plus 'None'" do
+          allow(Octopolo::GitHub::Label).to receive(:all) { github_labels }
+          expect(subject.send(:label_choices)).to eq github_labels
+        end
+      end
+
+      context "#update_pivotal" do
+        before do
+          subject.pivotal_ids = %w(123 234)
+          subject.issue = stub(url: "test")
+        end
+        let(:story_commenter) { stub(perform: true) }
+
+        it "creates a story commenter for each pivotal_id" do
+          Pivotal::StoryCommenter.should_receive(:new).with("123", "test") { story_commenter }
+          Pivotal::StoryCommenter.should_receive(:new).with("234", "test") { story_commenter }
+          subject.send(:update_pivotal)
+        end
+
+      end
+
+      context "#update_jira" do
+        before do
+          subject.jira_ids = %w(123 234)
+          subject.issue = stub(url: "test")
+        end
+        let(:story_commenter) { stub(perform: true) }
+
+        it "creates a story commenter for each pivotal_id" do
+          Jira::StoryCommenter.should_receive(:new).with("123", "test") { story_commenter }
+          Jira::StoryCommenter.should_receive(:new).with("234", "test") { story_commenter }
+          subject.send(:update_jira)
+        end
+      end
+
+      context "#update_label" do
+        before do
+          subject.label = "high-risk"
+          subject.issue = stub()
+        end
+        it "calls update_label with proper arguments" do
+          expect(subject.issue).to receive(:add_labels).with('high-risk')
+          subject.send(:update_label)
+        end
+
+        context "doesn't know yet label" do
+          before do
+            subject.label = nil
+          end
+          it "doesn't call update_label when label is don't know yet" do
+            expect(subject.issue).to_not receive(:add_labels)
+            subject.send(:update_label)
+          end
+        end
+
+      end
+
+      context "#open_issue" do
+        before do
+          subject.issue = issue
+          issue.stub(:url) { issue_url }
+        end
+
+        it "copies the issue's URL to the clipboard and opens it in the browser" do
+          cli.should_receive(:copy_to_clipboard) { issue.url}
+          cli.should_receive(:open) { issue.url }
+          subject.send(:open_issue)
+        end
+      end
+    end
+  end
+end

--- a/spec/octopolo/scripts/issue_spec.rb
+++ b/spec/octopolo/scripts/issue_spec.rb
@@ -42,7 +42,7 @@ module Octopolo
           expect(subject).to receive(:update_pivotal)
           expect(subject).to receive(:update_jira)
           expect(subject).to receive(:update_label)
-          expect(subject).to receive(:open_issue)
+          expect(subject).to receive(:open_in_browser)
 
           subject.execute
         end
@@ -216,7 +216,7 @@ module Octopolo
 
       end
 
-      context "#open_issue" do
+      context "#open_in_browser" do
         before do
           subject.issue = issue
           issue.stub(:url) { issue_url }
@@ -225,7 +225,7 @@ module Octopolo
         it "copies the issue's URL to the clipboard and opens it in the browser" do
           cli.should_receive(:copy_to_clipboard) { issue.url}
           cli.should_receive(:open) { issue.url }
-          subject.send(:open_issue)
+          subject.send(:open_in_browser)
         end
       end
     end

--- a/spec/octopolo/scripts/pull_request_spec.rb
+++ b/spec/octopolo/scripts/pull_request_spec.rb
@@ -45,7 +45,7 @@ module Octopolo
           expect(subject).to receive(:update_pivotal)
           expect(subject).to receive(:update_jira)
           expect(subject).to receive(:update_label)
-          expect(subject).to receive(:open_pull_request)
+          expect(subject).to receive(:open_in_browser)
 
           subject.execute
         end
@@ -255,7 +255,7 @@ module Octopolo
 
       end
 
-      context "#open_pull_request" do
+      context "#open_in_browser" do
         before do
           subject.pull_request = pull_request
           pull_request.stub(:url) { pull_request_url }
@@ -264,7 +264,7 @@ module Octopolo
         it "copies the pull request's URL to the clipboard and opens it in the browser" do
           cli.should_receive(:copy_to_clipboard) { pull_request.url}
           cli.should_receive(:open) { pull_request.url }
-          subject.send(:open_pull_request)
+          subject.send(:open_in_browser)
         end
       end
     end


### PR DESCRIPTION
# Description

Its like `pull-request` but for issues.

Upgraded octokit to fix bug with issue creation. 

Sharing some code between them since as far as the GitHub API is concerned, every pull request is an issue, but not every issue is a pull request.

# QA
`bundle exec octopolo issue` - verify issue creation
`bundle exec octopolo pull-request` - verify pr creation
