### PR TITLE
Don't raise on missing config file

### DIFF
--- a/lib/octopolo/commands/issue.rb
+++ b/lib/octopolo/commands/issue.rb
@@ -1,10 +1,7 @@
 desc "Create an issue for the current project."
 command 'issue' do |c|
-  config = Octopolo::Config.parse
-  user_config = Octopolo::UserConfig.parse
-
   c.desc "Use $EDITOR to update PR description before creating"
-  c.switch [:e, :editor], :default_value => user_config.editor
+  c.switch [:e, :editor], :default_value => Octopolo.user_config.editor
 
   c.action do |global_options, options, args|
     require_relative '../scripts/issue'

--- a/lib/octopolo/commands/pull_request.rb
+++ b/lib/octopolo/commands/pull_request.rb
@@ -1,13 +1,10 @@
 desc "Create a pull request from the current branch to the application's designated deploy branch."
 command 'pull-request' do |c|
-  config = Octopolo::Config.parse
-  user_config = Octopolo::UserConfig.parse
-
   c.desc "Branch to create the pull request against"
-  c.flag [:d, :dest, :destination], :arg_name => "destination_branch", :default_value => config.deploy_branch
+  c.flag [:d, :dest, :destination], :arg_name => "destination_branch", :default_value => Octopolo.config.deploy_branch
 
   c.desc "Use $EDITOR to update PR description before creating"
-  c.switch [:e, :editor], :default_value => user_config.editor
+  c.switch [:e, :editor], :default_value => Octopolo.user_config.editor
 
   c.action do |global_options, options, args|
     require_relative '../scripts/pull_request'

--- a/lib/octopolo/commands/sync_branch.rb
+++ b/lib/octopolo/commands/sync_branch.rb
@@ -1,8 +1,7 @@
-config = Octopolo::Config.parse
-long_desc "branch - Which branch to merge into yours (default: #{config.deploy_branch})"
+long_desc "branch - Which branch to merge into yours (default: #{Octopolo.config.deploy_branch})"
 
 arg :branch
-desc "Merge the #{config.deploy_branch} branch into the current working branch"
+desc "Merge the #{Octopolo.config.deploy_branch} branch into the current working branch"
 command 'sync-branch' do |c|
   c.action do |global_options, options, args|
     require_relative '../scripts/sync_branch'

--- a/lib/octopolo/config.rb
+++ b/lib/octopolo/config.rb
@@ -88,11 +88,13 @@ module Octopolo
     # end defaults
 
     def self.parse
-      new(attributes_from_file)
+      new(attributes_from_file || {})
     end
 
     def self.attributes_from_file
-      YAML.load_file(octopolo_config_path)
+      if path = octopolo_config_path
+        YAML.load_file(path)
+      end
     end
 
     def self.octopolo_config_path
@@ -104,8 +106,7 @@ module Octopolo
         if old_dir != Dir.pwd
           octopolo_config_path
         else
-          Octopolo::CLI.say "Could not find #{FILE_NAMES.join(' or ')}"
-          exit
+          Octopolo::CLI.say "*** WARNING: Could not find #{FILE_NAMES.join(' or ')} ***"
         end
       end
     end

--- a/spec/octopolo/config_spec.rb
+++ b/spec/octopolo/config_spec.rb
@@ -237,8 +237,8 @@ module Octopolo
 
       it "gives up if it can't find a config file" do
         File.stub(:exists?) { false }
-        Octopolo::CLI.should_receive(:say).with("Could not find .octopolo.yml or .automation.yml")
-        lambda { subject.octopolo_config_path }.should raise_error(SystemExit)
+        Octopolo::CLI.should_receive(:say).with("*** WARNING: Could not find .octopolo.yml or .automation.yml ***")
+        subject.octopolo_config_path
         Dir.chdir project_working_dir
       end
 


### PR DESCRIPTION
Features were added that cause eager loading of the configuration file for default command flags. This causes Octopolo to exit in error instead of providing help information and allowing you to set up Github auth for your user when you don't have a config file. That should be allowed.

This changes Octopolo to merely print a nice warning message saying it couldn't find your config file, allowing you access to those other functions. Also bubbles up messages from the Github wrapper which isn't so bad at all:

```plaintext
$ op view-pr
*** WARNING: Could not find .octopolo.yml or .automation.yml ***
An error occurred while getting the current branch: GitHub Repo is required
```

Fixes #76

r? @anfleene