### PR TITLE
IS-4641-spring-cleaning-jira-bomb

### DIFF
--- a/lib/octopolo/jira/story_commenter.rb
+++ b/lib/octopolo/jira/story_commenter.rb
@@ -17,19 +17,16 @@ module Octopolo
         begin
           self.issue =  Jiralicious::Issue.find issue_id
         rescue => e
-           puts e.message
-           puts "Invalid Jira Story ID" 
+           puts "Error: Invalid Jira Issue #{issue_id}" 
         end
-        
-          self.comment = comment
+        self.comment = comment
       end
 
       def perform
         begin
           issue.comments.add(comment)
         rescue => e
-          puts e.message
-          puts "Error commenting on Jira Story" 
+          puts "Error: Failed to comment on Jira Issue #{issue_id}" 
         end
       end
     end

--- a/lib/octopolo/jira/story_commenter.rb
+++ b/lib/octopolo/jira/story_commenter.rb
@@ -14,12 +14,23 @@ module Octopolo
           jira_config.password = config.jira_password
           jira_config.uri = config.jira_url
         end
-        self.issue =  Jiralicious::Issue.find issue_id
-        self.comment = comment
+        begin
+          self.issue =  Jiralicious::Issue.find issue_id
+        rescue => e
+           puts e.message
+           puts "Invalid Jira Story ID" 
+        end
+        
+          self.comment = comment
       end
 
       def perform
-        issue.comments.add(comment)
+        begin
+          issue.comments.add(comment)
+        rescue => e
+          puts e.message
+          puts "Error commenting on Jira Story" 
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes Octopolo so that it doesn't bomb when Jira Story ID is invalid or if Jira's API fails.

Rollback Plan
-------------
**If this pull request requires anything more complex (e.g., rolling back a migration), you MUST update this section. Otherwise, delete this note.**

To roll back this change, revert the merge with `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
* [Jira issue kajsndkfa](https://sportngin.atlassian.net/browse/kajsndkfa) <== Proof that it works

QA Plan
-------
- [x] check out this branch and make a new branch from it
- [x] make a small change like adding a new  file and commit it
- [x] run `bundle exec op pull-request`
  - [x] enter an invalid Jira issue ID
  - [x] Octopolo shouldn't fail
