### PR TITLE
HD-OPEN-1 Prevent New Branch from Blowing Up Without Config Files

### DIFF
--- a/lib/octopolo/config.rb
+++ b/lib/octopolo/config.rb
@@ -102,6 +102,7 @@ module Octopolo
     end
 
     def self.octopolo_config_path
+      @project_dir ||= Dir.pwd
       if filepath = FILE_NAMES.detect {|filename| File.exists?(filename)}
         File.join(Dir.pwd, filepath)
       else
@@ -110,8 +111,8 @@ module Octopolo
         if old_dir != Dir.pwd
           octopolo_config_path
         else
-          Octopolo::CLI.say "*** Generating .octopolo.yml file... ***"
-          File.new(".octopolo.yml", "w+")
+          Dir.chdir(@project_dir)
+          return
         end
       end
     end

--- a/lib/octopolo/config.rb
+++ b/lib/octopolo/config.rb
@@ -110,7 +110,8 @@ module Octopolo
         if old_dir != Dir.pwd
           octopolo_config_path
         else
-          Octopolo::CLI.say "*** WARNING: Could not find #{FILE_NAMES.join(' or ')} ***"
+          Octopolo::CLI.say "*** Generating .octopolo.yml file... ***"
+          File.new(".octopolo.yml", "w+")
         end
       end
     end

--- a/lib/octopolo/config.rb
+++ b/lib/octopolo/config.rb
@@ -41,7 +41,11 @@ module Octopolo
     end
 
     def github_repo
-      @github_repo || /(?<=:)\S+(?=\.)/.match(Octopolo::CLI.perform "git config --get remote.origin.url") || raise(MissingRequiredAttribute, "GitHub Repo is required")
+      @github_repo || find_repo || raise(MissingRequiredAttribute, "GitHub Repo is required")
+    end
+
+    def find_repo
+      /(?<=:)\S+(?=\.)/.match(Octopolo::CLI.perform "git config --get remote.origin.url")
     end
 
     def merge_resolver

--- a/lib/octopolo/config.rb
+++ b/lib/octopolo/config.rb
@@ -41,11 +41,11 @@ module Octopolo
     end
 
     def github_repo
-      @github_repo || raise(MissingRequiredAttribute, "GitHub Repo is required")
+      @github_repo || /(?<=:)\S+(?=\.)/.match(Octopolo::CLI.perform "git config --get remote.origin.url") || raise(MissingRequiredAttribute, "GitHub Repo is required")
     end
 
     def merge_resolver
-      @merge_resolver 
+      @merge_resolver
     end
 
     def user_notifications

--- a/spec/octopolo/config_spec.rb
+++ b/spec/octopolo/config_spec.rb
@@ -245,13 +245,6 @@ module Octopolo
       subject { Config }
       before { project_working_dir }
 
-      it "gives up if it can't find a config file" do
-        File.stub(:exists?) { false }
-        Octopolo::CLI.should_receive(:say).with("*** WARNING: Could not find .octopolo.yml or .automation.yml ***")
-        subject.octopolo_config_path
-        Dir.chdir project_working_dir
-      end
-
       context "with a .octopolo.yml file" do
         before do
           FileUtils.cp "spec/support/sample_octopolo.yml", "spec/support/.octopolo.yml"

--- a/spec/octopolo/config_spec.rb
+++ b/spec/octopolo/config_spec.rb
@@ -62,7 +62,7 @@ module Octopolo
         end
       end
 
-      context "#deployable_label" do 
+      context "#deployable_label" do
         it "is true by default" do
           expect(Config.new.deployable_label).to eq(true)
         end
@@ -73,8 +73,8 @@ module Octopolo
       end
 
       context "#github_repo" do
-        it "raises an exception if not given" do
-          expect { Config.new.github_repo }.to raise_error(Config::MissingRequiredAttribute)
+        it "finds repo when not given" do
+          Config.any_instance.github_repo.stub(:find_repo) { 'foo/ngin-bar' }
         end
 
         it "returns the specified value otherwise" do

--- a/spec/octopolo/config_spec.rb
+++ b/spec/octopolo/config_spec.rb
@@ -74,7 +74,7 @@ module Octopolo
 
       context "#github_repo" do
         it "finds repo when not given" do
-          Config.any_instance.github_repo.stub(:find_repo) { 'foo/ngin-bar' }
+          Config.any_instance.stub(:find_repo) { 'foo/ngin-bar' }
         end
 
         it "returns the specified value otherwise" do


### PR DESCRIPTION
## Description

Stop Octopolo from failing hard when no config files are present during `new-branch` command. Also finds current repository during `pull-request` command to avoid errors.
## Deploy Plan

Does Infrastructure need to know anything special about this deploy? If so, keep this section and fill it in. **Otherwise, delete it.**
## Rollback Plan

**If this pull request requires anything more complex (e.g., rolling back a migration), you MUST update this section. Otherwise, delete this note.**

To roll back this change, revert the merge with `git revert -m 1 MERGE_SHA` and perform another deploy.
## URLs
## QA Plan

NEW BRANCH:
- Try to create a new branch without config files
- [ ] delete `.octopolo.yml` and `.autmation.yml` files if they exist
- [ ] op new-branch "branch_name"
- [ ] it fails!!!
- Pull repo and try to create a new branch locally without config files
- [ ] delete `.octopolo.yml` and `.autmation.yml` files if they exist
- [ ] be bin/op new-branch "branch_name"
- [ ] branch is created successfully

NEW PULL REQUEST:
- Pull master to remove above changes
- [ ] create an empty `octopolo.yml` file or comment out the github_repo line inside it if present
- [ ] op pull-request
- [ ] if fails with "Github repo is required" error
- Pull repo and try to create a pull request locally
- [ ] create an empty `octopolo.yml` file or comment out the github_repo line inside it if present
- [ ] be bin/op pull-request
- [ ] PR workflow is launched successfully
