### PR TITLE
Check PR status before marking deployable/accept-pull

### DIFF
--- a/lib/octopolo/commands/accept_pull.rb
+++ b/lib/octopolo/commands/accept_pull.rb
@@ -1,8 +1,9 @@
 arg :pull_request_id
 desc 'Accept pull requests. Merges the given pull request into master and updates the changelog.'
 command 'accept-pull' do |c|
+  c.switch :'ignore-status-checks', :default_value => false, :desc => 'Ignore the status check on the pull request', :negatable => false
   c.action do |global_options, options, args|
     require_relative '../scripts/accept_pull'
-    Octopolo::Scripts::AcceptPull.execute args.first
+    Octopolo::Scripts::AcceptPull.execute(args.first, options)
   end
 end

--- a/lib/octopolo/commands/accept_pull.rb
+++ b/lib/octopolo/commands/accept_pull.rb
@@ -1,7 +1,7 @@
 arg :pull_request_id
 desc 'Accept pull requests. Merges the given pull request into master and updates the changelog.'
 command 'accept-pull' do |c|
-  c.switch :'ignore-status-checks', default_value: false, desc: 'Ignore the status check on the pull request', negatable: false
+  c.switch [:f, :force], default_value: false, desc: 'Ignore the status checks on the pull request', negatable: false
   c.action do |global_options, options, args|
     require_relative '../scripts/accept_pull'
     Octopolo::Scripts::AcceptPull.execute(args.first, options)

--- a/lib/octopolo/commands/accept_pull.rb
+++ b/lib/octopolo/commands/accept_pull.rb
@@ -1,7 +1,7 @@
 arg :pull_request_id
 desc 'Accept pull requests. Merges the given pull request into master and updates the changelog.'
 command 'accept-pull' do |c|
-  c.switch :'ignore-status-checks', :default_value => false, :desc => 'Ignore the status check on the pull request', :negatable => false
+  c.switch :'ignore-status-checks', default_value: false, desc: 'Ignore the status check on the pull request', negatable: false
   c.action do |global_options, options, args|
     require_relative '../scripts/accept_pull'
     Octopolo::Scripts::AcceptPull.execute(args.first, options)

--- a/lib/octopolo/commands/deployable.rb
+++ b/lib/octopolo/commands/deployable.rb
@@ -1,7 +1,7 @@
 arg :pull_request_id
 desc 'Merges PR into the deployable branch'
 command 'deployable' do |c|
-  c.switch :'ignore-status-checks', default_value: false, desc: 'Ignore the status check on the pull request', negatable: false
+  c.switch [:f, :force], default_value: false, desc: 'Ignore the status checks on the pull request', negatable: false
   c.action do |global_options, options, args|
     require_relative '../scripts/deployable'
     Octopolo::Scripts::Deployable.execute(args.first, options)

--- a/lib/octopolo/commands/deployable.rb
+++ b/lib/octopolo/commands/deployable.rb
@@ -1,8 +1,9 @@
 arg :pull_request_id
 desc 'Merges PR into the deployable branch'
 command 'deployable' do |c|
+  c.switch :'ignore-status-checks', default_value: false, desc: 'Ignore the status check on the pull request', negatable: false
   c.action do |global_options, options, args|
     require_relative '../scripts/deployable'
-    Octopolo::Scripts::Deployable.execute args.first
+    Octopolo::Scripts::Deployable.execute(args.first, options)
   end
 end

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -117,6 +117,10 @@ module Octopolo
       client.search_issues *args
     end
 
+    def self.status *args
+      client.status *args
+    end
+
 
     # now that you've set up your credentials, try again
     TryAgain = Class.new(StandardError)

--- a/lib/octopolo/github/pull_request.rb
+++ b/lib/octopolo/github/pull_request.rb
@@ -69,6 +69,14 @@ module Octopolo
         @commits ||= Commit.for_pull_request self
       end
 
+      def status_checks_passed?
+        status == 'success'
+      end
+
+      def status
+        GitHub.status(repo_name, data.head.sha)[:state]
+      end
+
       def self.current
         current_branch = Git.current_branch
         query = "repo:#{config.github_repo} type:pr is:open head:#{current_branch}"

--- a/lib/octopolo/scripts/accept_pull.rb
+++ b/lib/octopolo/scripts/accept_pull.rb
@@ -13,13 +13,14 @@ module Octopolo
 
       attr_accessor :pull_request_id
 
-      def self.execute(pull_request_id)
+      def self.execute(pull_request_id, options)
         pull_request_id ||= Integer(cli.prompt "Pull Request ID: ")
-        new(pull_request_id).execute
+        new(pull_request_id, options).execute
       end
 
-      def initialize(pull_request_id)
+      def initialize(pull_request_id, options={})
         @pull_request_id = pull_request_id
+        @ignore_status_checks = options[:'ignore-status-checks']
       end
 
       # Public: Perform the script
@@ -36,10 +37,16 @@ module Octopolo
       def merge pull_request
         Git.fetch
         if pull_request.mergeable?
-          cli.perform "git merge --no-ff origin/#{pull_request.branch} -m \"Merge pull request ##{pull_request_id} from origin/#{pull_request.branch}\""
+          if pull_request.status_checks_passed? || @ignore_status_checks
+            cli.perform "git merge --no-ff origin/#{pull_request.branch} -m \"Merge pull request ##{pull_request_id} from origin/#{pull_request.branch}\""
+          else
+            cli.say 'Status checks have not passed on this pull request.'
+            exit!
+          end
         else
           cli.say "There is a merge conflict with this branch and #{config.deploy_branch}."
           cli.say "Please update this branch with #{config.deploy_branch} or perform the merge manually and fix any conflicts"
+          exit!
         end
       end
 

--- a/lib/octopolo/scripts/accept_pull.rb
+++ b/lib/octopolo/scripts/accept_pull.rb
@@ -20,7 +20,7 @@ module Octopolo
 
       def initialize(pull_request_id, options={})
         @pull_request_id = pull_request_id
-        @ignore_status_checks = options['ignore-status-checks']
+        @force = options[:force]
       end
 
       # Public: Perform the script
@@ -37,7 +37,7 @@ module Octopolo
       def merge pull_request
         Git.fetch
         if pull_request.mergeable?
-          if pull_request.status_checks_passed? || @ignore_status_checks
+          if pull_request.status_checks_passed? || @force
             cli.perform "git merge --no-ff origin/#{pull_request.branch} -m \"Merge pull request ##{pull_request_id} from origin/#{pull_request.branch}\""
           else
             cli.say 'Status checks have not passed on this pull request.'

--- a/lib/octopolo/scripts/accept_pull.rb
+++ b/lib/octopolo/scripts/accept_pull.rb
@@ -20,7 +20,7 @@ module Octopolo
 
       def initialize(pull_request_id, options={})
         @pull_request_id = pull_request_id
-        @ignore_status_checks = options[:'ignore-status-checks']
+        @ignore_status_checks = options['ignore-status-checks']
       end
 
       # Public: Perform the script

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -33,7 +33,7 @@ module Octopolo
           if config.deployable_label
             with_labelling do
               merge
-            end
+            end if deployable?
           else
             merge
           end
@@ -46,13 +46,22 @@ module Octopolo
       private :merge
 
       def with_labelling(&block)
-        pull_request = Octopolo::GitHub::PullRequest.new(config.github_repo, @pull_request_id)
         pull_request.add_labels(Deployable.deployable_label)
         unless yield
           pull_request.remove_labels(Deployable.deployable_label)
         end
       end
       private :with_labelling
+
+      def deployable?
+        pull_request.mergeable? && pull_request.status_checks_passed?
+      end
+      private :deployable?
+
+      def pull_request
+        @pull_request ||= Octopolo::GitHub::PullRequest.new(config.github_repo, @pull_request_id)
+      end
+      private :pull_request
     end
   end
 end

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -30,10 +30,14 @@ module Octopolo
         end
         self.pull_request_id ||= cli.prompt("Pull Request ID: ")
         GitHub.connect do
+          unless deployable?
+            CLI.say 'Pull request status checks have not passed. Cannot be marked deployable.'
+            exit!
+          end
           if config.deployable_label
             with_labelling do
               merge
-            end if deployable?
+            end
           else
             merge
           end

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -10,16 +10,17 @@ module Octopolo
 
       attr_accessor :pull_request_id
 
-      def self.execute(pull_request_id=nil)
-        new(pull_request_id).execute
+      def self.execute(pull_request_id=nil, options={})
+        new(pull_request_id, options).execute
       end
 
       def self.deployable_label
         Octopolo::GitHub::Label.new(name: "deployable", color: "428BCA")
       end
 
-      def initialize(pull_request_id=nil)
+      def initialize(pull_request_id=nil, options={})
         @pull_request_id = pull_request_id
+        @ignore_status_checks = options['ignore-status-checks']
       end
 
       # Public: Perform the script
@@ -30,7 +31,7 @@ module Octopolo
         end
         self.pull_request_id ||= cli.prompt("Pull Request ID: ")
         GitHub.connect do
-          unless deployable?
+          unless deployable? || @ignore_status_checks
             CLI.say 'Pull request status checks have not passed. Cannot be marked deployable.'
             exit!
           end

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -20,7 +20,7 @@ module Octopolo
 
       def initialize(pull_request_id=nil, options={})
         @pull_request_id = pull_request_id
-        @ignore_status_checks = options['ignore-status-checks']
+        @force = options[:force]
       end
 
       # Public: Perform the script
@@ -31,7 +31,7 @@ module Octopolo
         end
         self.pull_request_id ||= cli.prompt("Pull Request ID: ")
         GitHub.connect do
-          unless deployable? || @ignore_status_checks
+          unless deployable? || @force
             CLI.say 'Pull request status checks have not passed. Cannot be marked deployable.'
             exit!
           end

--- a/spec/octopolo/scripts/accept_pull_spec.rb
+++ b/spec/octopolo/scripts/accept_pull_spec.rb
@@ -91,6 +91,18 @@ module Octopolo
             subject.merge pull_request
           end
         end
+
+        context "when failed status checks should be ignored" do
+          subject { described_class.new(pull_request_id, force: true) }
+          before { pull_request.stub(mergeable?: true, status_checks_passed?: false) }
+
+          it "fetches and merges the request's branch" do
+            Git.should_receive(:fetch)
+            cli.should_receive(:perform).with "git merge --no-ff origin/#{pull_request.branch} -m \"Merge pull request ##{pull_request_id} from origin/#{pull_request.branch}\""
+
+            subject.merge pull_request
+          end
+        end
       end
     end
   end

--- a/spec/octopolo/scripts/accept_pull_spec.rb
+++ b/spec/octopolo/scripts/accept_pull_spec.rb
@@ -47,8 +47,8 @@ module Octopolo
         let(:pull_request) { stub(branch: "foobranch") }
         before { subject.stub(:pull_request_id => pull_request_id) }
 
-        context "when mergeable" do
-          before { pull_request.stub(mergeable?: true) }
+        context "when mergeable and status checks passed" do
+          before { pull_request.stub(mergeable?: true, status_checks_passed?: true) }
 
           it "fetches and merges the request's branch" do
             Git.should_receive(:fetch)
@@ -59,7 +59,10 @@ module Octopolo
         end
 
         context "when not mergeable" do
-          before { pull_request.stub(mergeable?: false) }
+          before do
+            pull_request.stub(mergeable?: false)
+            allow(subject).to receive(:exit!)
+          end
 
           it "performs the merge and alerts about potential failures" do
             Git.should_receive(:fetch)
@@ -67,6 +70,24 @@ module Octopolo
             cli.should_not_receive(:perform).with "git merge --no-ff origin/#{pull_request.branch} -m \"Merge pull request ##{pull_request_id} from origin/#{pull_request.branch}\""
 
             cli.should_receive(:say).with /merge conflict/
+            expect(subject).to receive(:exit!)
+            subject.merge pull_request
+          end
+        end
+
+        context "when mergeable and status checks have not passed" do
+          before do
+            pull_request.stub(mergeable?: true, status_checks_passed?: false)
+            allow(subject).to receive(:exit!)
+          end
+
+          it "performs the merge and alerts about potential failures" do
+            Git.should_receive(:fetch)
+            cli.stub(:say)
+            cli.should_not_receive(:perform).with "git merge --no-ff origin/#{pull_request.branch} -m \"Merge pull request ##{pull_request_id} from origin/#{pull_request.branch}\""
+
+            cli.should_receive(:say).with 'Status checks have not passed on this pull request.'
+            expect(subject).to receive(:exit!)
             subject.merge pull_request
           end
         end

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -75,26 +75,6 @@ module Octopolo
             end
           end
 
-          context "when pr is not mergeable" do
-            before do
-              pull_request.stub(mergeable?: false)
-            end
-
-            it "does not add the labels" do
-              pull_request.should_not_receive(:add_labels)
-            end
-          end
-
-          context "when pr has not passed status checks" do
-            before do
-              pull_request.stub(status_checks_passed?: false)
-            end
-
-            it "does not add the labels" do
-              pull_request.should_not_receive(:add_labels)
-            end
-          end
-
           context "when the merge to deployable succeeds" do
             it "doesn't remove the deployable label" do
               pull_request.should_not_receive(:remove_labels)
@@ -121,6 +101,27 @@ module Octopolo
             pull_request.should_not_receive(:add_labels)
           end
         end
+
+        context "when pr is not mergeable" do
+          before do
+            pull_request.stub(mergeable?: false)
+          end
+
+          it "prints out an error and exits" do
+            expect(CLI).to receive(:say).with("Pull request status checks have not passed. Cannot be marked deployable.")
+          end
+        end
+
+        context "when pr has not passed status checks" do
+          before do
+            pull_request.stub(status_checks_passed?: false)
+          end
+
+          it "prints out an error and exits" do
+            expect(CLI).to receive(:say).with("Pull request status checks have not passed. Cannot be marked deployable.")
+          end
+        end
+
       end
     end
   end

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -105,20 +105,24 @@ module Octopolo
         context "when pr is not mergeable" do
           before do
             pull_request.stub(mergeable?: false)
+            allow(subject).to receive(:exit!)
           end
 
           it "prints out an error and exits" do
             expect(CLI).to receive(:say).with("Pull request status checks have not passed. Cannot be marked deployable.")
+            expect(subject).to receive(:exit!)
           end
         end
 
         context "when pr has not passed status checks" do
           before do
             pull_request.stub(status_checks_passed?: false)
+            allow(subject).to receive(:exit!)
           end
 
           it "prints out an error and exits" do
             expect(CLI).to receive(:say).with("Pull request status checks have not passed. Cannot be marked deployable.")
+            expect(subject).to receive(:exit!)
           end
         end
 

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -126,8 +126,8 @@ module Octopolo
           end
         end
 
-        context "when pr has not passed status checks but should be ignored" do
-          subject { described_class.new(42, 'ignore-status-checks' => true) }
+        context "when failed status checks should be ignored" do
+          subject { described_class.new(42, force: true) }
           before { pull_request.stub(status_checks_passed?: false) }
 
           it "adds the deployable label" do

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -10,7 +10,11 @@ module Octopolo
       let(:config) { stub(user_notifications: ['NickLaMuro'],
                           github_repo: 'grumpy_cat',
                           deployable_label: true) }
-      let(:pull_request) { stub(add_labels: true, remove_labels: true, number: 7) }
+      let(:pull_request) { stub(add_labels: true,
+                                remove_labels: true,
+                                number: 7,
+                                mergeable?: true,
+                                status_checks_passed?: true) }
       before do
         allow(subject).to receive(:cli) { cli }
         allow(subject).to receive(:config) { config }
@@ -68,6 +72,26 @@ module Octopolo
 
             it "removes the deployable label" do
               pull_request.should_receive(:remove_labels)
+            end
+          end
+
+          context "when pr is not mergeable" do
+            before do
+              pull_request.stub(mergeable?: false)
+            end
+
+            it "does not add the labels" do
+              pull_request.should_not_receive(:add_labels)
+            end
+          end
+
+          context "when pr has not passed status checks" do
+            before do
+              pull_request.stub(status_checks_passed?: false)
+            end
+
+            it "does not add the labels" do
+              pull_request.should_not_receive(:add_labels)
             end
           end
 

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -126,6 +126,15 @@ module Octopolo
           end
         end
 
+        context "when pr has not passed status checks but should be ignored" do
+          subject { described_class.new(42, 'ignore-status-checks' => true) }
+          before { pull_request.stub(status_checks_passed?: false) }
+
+          it "adds the deployable label" do
+            pull_request.should_receive(:add_labels)
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
## Description

If a repository has status checks enabled, ensure that the all the checks have passed before:

- a pull request can be marked `deployable`
- a pull request can be accepted

## QA Plan

### deployable
- [ ] Attempt to mark a PR as deployable if it hasn't passed its status checks. This should fail.
![2__arvindmenon_arvind-menon-mbp____sportngin_auto_mobile_test__zsh__and_testing_deployability_by_amenon_ _pull_request__10_ _sportngin_auto_mobile_test](https://cloud.githubusercontent.com/assets/1328587/20226638/79c66d04-a80e-11e6-8587-e3c2830b483b.jpg)

- [ ] After the status checks have passed, this should succeed and mark the PR as deployable
![2__arvindmenon_arvind-menon-mbp____sportngin_auto_mobile_test__zsh__and_testing_deployability_by_amenon_ _pull_request__10_ _sportngin_auto_mobile_test](https://cloud.githubusercontent.com/assets/1328587/20226679/a4b24524-a80e-11e6-932e-033174498c93.jpg)

### accept-pull
- [ ] Attempt to accept a PR as deployable if it hasn't passed its status checks. This should fail.
![2__arvindmenon_arvind-menon-mbp____sportngin_auto_mobile_test__zsh__and_testing_deployability_by_amenon_ _pull_request__10_ _sportngin_auto_mobile_test](https://cloud.githubusercontent.com/assets/1328587/20228189/d6b5c15c-a815-11e6-9b57-0cbc70b04b5d.jpg)

- [ ] Force accept a PR even if the status checks haven't passed
![2__arvindmenon_arvind-menon-mbp____sportngin_auto_mobile_test__zsh__and_testing_deployability_by_amenon_ _pull_request__10_ _sportngin_auto_mobile_test](https://cloud.githubusercontent.com/assets/1328587/20228204/eed71b14-a815-11e6-8e6b-b7cc919377ef.jpg)

- [ ] `accept-pull` should succeed if the PR status checks have passed
![2__arvindmenon_arvind-menon-mbp____sportngin_auto_mobile_test__zsh__and_testing_deployability_by_amenon_ _pull_request__10_ _sportngin_auto_mobile_test](https://cloud.githubusercontent.com/assets/1328587/20228250/19d75aae-a816-11e6-94ec-698056bf923d.jpg)
