### PR TITLE
Github team_member? method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ branches:
 language: ruby
 rvm:
   - 2.0
-  - 2.1
-  - 2.2
-script: bundle exec rspec
+script: bundle
+before_install:
+- gem uninstall bundler && gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ branches:
 language: ruby
 rvm:
   - 2.0
-script: bundle
+script: bundle exec rspec
 before_install:
 - gem uninstall bundler && gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ branches:
 language: ruby
 rvm:
   - 2.0
+  - 2.1
+  - 2.2
 script: bundle exec rspec
 before_install:
 - gem uninstall bundler && gem install bundler

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -124,11 +124,6 @@ module Octopolo
     def self.team_member? team
       client.team_member? team, user_config.github_user
     end
-
-    def self.pull_merged? *args
-      client.pull_merged? *args
-    end
-
     # now that you've set up your credentials, try again
     TryAgain = Class.new(StandardError)
     # the credentials you've entered are bad

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -124,7 +124,7 @@ module Octopolo
     def self.team_member? team
       client.team_member? team, user_config.github_user
     end
-    
+
     # now that you've set up your credentials, try again
     TryAgain = Class.new(StandardError)
     # the credentials you've entered are bad

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -121,6 +121,9 @@ module Octopolo
       client.status *args
     end
 
+    def self.team_member? team
+      client.team_member? team, user_config.github_user
+    end
 
     # now that you've set up your credentials, try again
     TryAgain = Class.new(StandardError)

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -125,6 +125,10 @@ module Octopolo
       client.team_member? team, user_config.github_user
     end
 
+    def self.pull_merged? *args
+      client.pull_merged? *args
+    end
+
     # now that you've set up your credentials, try again
     TryAgain = Class.new(StandardError)
     # the credentials you've entered are bad

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -124,6 +124,7 @@ module Octopolo
     def self.team_member? team
       client.team_member? team, user_config.github_user
     end
+    
     # now that you've set up your credentials, try again
     TryAgain = Class.new(StandardError)
     # the credentials you've entered are bad

--- a/spec/octopolo/github_spec.rb
+++ b/spec/octopolo/github_spec.rb
@@ -179,6 +179,28 @@ module Octopolo
           end
         end
       end
+
+      context ".team_member? team" do
+        let(:valid_team) { 2396228 }
+        let(:invalid_team) { 2396227 }
+        let(:user_config) { stub(:user_config, github_user: "foo", github_token: "bar") }
+
+        before { GitHub.stub(user_config: user_config) }
+
+        context "when valid team member" do
+          it "returns true" do
+            client.should_receive(:team_member?).with(valid_team, user_config.github_user) { true }
+            GitHub.team_member?(valid_team).should == true
+          end
+        end
+
+        context "when not a valid team member" do
+          it "returns false" do
+            client.should_receive(:team_member?).with(invalid_team, user_config.github_user) { false }
+            GitHub.team_member?(invalid_team).should == false
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
What
----------------------
Adding a `team_membership?` method to the Github module in order to apply restrictions on certain AutoMobile commands

Why
----------------------
To restrict the use of new AutoMobile commands to certain users

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
* [Jira issue TEAM-4179](https://sportngin.atlassian.net/browse/TEAM-4133)

QA Plan
-------
I have tested this change in conjunction with AutoMobile's #154 using the auto_mobile_test repo with success, but I am not sure how to test this method while stand-alone.
- [ ] Can my tests ever even fail?