### PR TITLE
Fix merging into deployable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ rvm:
   - 2.2
 script: bundle exec rspec
 before_install:
-- gem uninstall bundler && gem install bundler
+- gem install bundler

--- a/lib/octopolo/pull_request_merger.rb
+++ b/lib/octopolo/pull_request_merger.rb
@@ -42,20 +42,19 @@ module Octopolo
         merge_pull_request
         comment_about_merge
       end
-    rescue GitHub::PullRequest::NotFound
-      cli.say "Unable to find pull request #{pull_request_id}. Please retry with a valid ID."
-      false
-    rescue Git::MergeFailed
-      cli.say "Merge failed. Please identify the source of this merge conflict resolve this conflict in your pull request's branch. NOTE: Merge conflicts resolved in the #{branch_type} branch are NOT used when deploying."
-      false
-    rescue Git::CheckoutFailed
-      cli.say "Checkout of #{branch_to_merge_into} failed. Please contact Infrastructure to determine the cause."
-      false
-    rescue GitHub::PullRequest::CommentFailed
-      cli.say "Unable to write comment. Please navigate to #{pull_request.url} and add the comment, '#{comment_body}'"
-      false
     rescue => e
-      cli.say "An unknown error occurred: #{e.inspect}"
+      case e
+      when GitHub::PullRequest::NotFound
+        cli.say "Unable to find pull request #{pull_request_id}. Please retry with a valid ID."
+      when Git::MergeFailed
+        cli.say "Merge failed. Please identify the source of this merge conflict resolve this conflict in your pull request's branch. NOTE: Merge conflicts resolved in the #{branch_type} branch are NOT used when deploying."
+      when Git::CheckoutFailed
+        cli.say "Checkout of #{branch_to_merge_into} failed. Please contact Infrastructure to determine the cause."
+      when GitHub::PullRequest::CommentFailed
+        cli.say "Unable to write comment. Please navigate to #{pull_request.url} and add the comment, '#{comment_body}'"
+      else
+        cli.say "An unknown error occurred: #{e.inspect}"
+      end
       false
     end
 

--- a/lib/octopolo/pull_request_merger.rb
+++ b/lib/octopolo/pull_request_merger.rb
@@ -42,19 +42,20 @@ module Octopolo
         merge_pull_request
         comment_about_merge
       end
+    rescue GitHub::PullRequest::NotFound
+      cli.say "Unable to find pull request #{pull_request_id}. Please retry with a valid ID."
+      false
+    rescue Git::MergeFailed
+      cli.say "Merge failed. Please identify the source of this merge conflict resolve this conflict in your pull request's branch. NOTE: Merge conflicts resolved in the #{branch_type} branch are NOT used when deploying."
+      false
+    rescue Git::CheckoutFailed
+      cli.say "Checkout of #{branch_to_merge_into} failed. Please contact Infrastructure to determine the cause."
+      false
+    rescue GitHub::PullRequest::CommentFailed
+      cli.say "Unable to write comment. Please navigate to #{pull_request.url} and add the comment, '#{comment_body}'"
+      false
     rescue => e
-      case e
-      when GitHub::PullRequest::NotFound
-        cli.say "Unable to find pull request #{pull_request_id}. Please retry with a valid ID."
-      when Git::MergeFailed
-        cli.say "Merge failed. Please identify the source of this merge conflict resolve this conflict in your pull request's branch. NOTE: Merge conflicts resolved in the #{branch_type} branch are NOT used when deploying."
-      when Git::CheckoutFailed
-        cli.say "Checkout of #{branch_to_merge_into} failed. Please contact Infrastructure to determine the cause."
-      when GitHub::PullRequest::CommentFailed
-        cli.say "Unable to write comment. Please navigate to #{pull_request.url} and add the comment, '#{comment_body}'"
-      else
-        cli.say "An unknown error occurred: #{e.inspect}"
-      end
+      cli.say "An unknown error occurred: #{e.inspect}"
       false
     end
 

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -35,13 +35,9 @@ module Octopolo
             CLI.say 'Pull request status checks have not passed. Cannot be marked deployable.'
             exit!
           end
-          if config.deployable_label
-            with_labelling do
-              merge
-            end
-          else
-            merge
-          end
+
+          merge_result = merge
+          add_deployable_label if config.deployable_label && merge_result
         end
       end
 
@@ -50,13 +46,10 @@ module Octopolo
       end
       private :merge
 
-      def with_labelling(&block)
+      def add_deployable_label
         pull_request.add_labels(Deployable.deployable_label)
-        unless yield
-          pull_request.remove_labels(Deployable.deployable_label)
-        end
       end
-      private :with_labelling
+      private :add_deployable_label
 
       def deployable?
         pull_request.mergeable? && pull_request.status_checks_passed?

--- a/lib/octopolo/scripts/deployable.rb
+++ b/lib/octopolo/scripts/deployable.rb
@@ -46,7 +46,7 @@ module Octopolo
       end
 
       def merge
-        PullRequestMerger.perform Git::DEPLOYABLE_PREFIX, Integer(@pull_request_id), :user_notifications => config.user_notifications
+        PullRequestMerger.new(Git::DEPLOYABLE_PREFIX, Integer(@pull_request_id), :user_notifications => config.user_notifications).perform
       end
       private :merge
 

--- a/octopolo.gemspec
+++ b/octopolo.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'semantic', '~> 1.3'
 
   gem.add_development_dependency 'rake', '~> 10.1'
+  gem.add_development_dependency 'bundler', '~> 1.16'
   gem.add_development_dependency 'rspec', '~> 2.99'
   gem.add_development_dependency 'guard', '~> 2.6'
   gem.add_development_dependency 'guard-rspec', '~> 4.3'

--- a/spec/octopolo/scripts/deployable_spec.rb
+++ b/spec/octopolo/scripts/deployable_spec.rb
@@ -19,7 +19,7 @@ module Octopolo
         allow(subject).to receive(:cli) { cli }
         allow(subject).to receive(:config) { config }
         allow(Octopolo::GitHub::PullRequest).to receive(:new) { pull_request }
-        allow(PullRequestMerger).to receive(:perform) { true }
+        allow_any_instance_of(PullRequestMerger).to receive(:perform) { true }
         allow(Octopolo::GitHub).to receive(:check_connection) { true }
       end
 
@@ -43,7 +43,7 @@ module Octopolo
             end
 
             it "takes the pull requests ID from the current branch" do
-              PullRequestMerger.should_receive(:perform).with(Git::DEPLOYABLE_PREFIX, pull_request.number, :user_notifications => config.user_notifications)
+              expect_any_instance_of(PullRequestMerger).to receive(:perform)
             end
           end
 
@@ -67,17 +67,17 @@ module Octopolo
 
           context "when merge to deployable fails" do
             before do
-              allow(PullRequestMerger).to receive(:perform) { false }
+              allow_any_instance_of(PullRequestMerger).to receive(:perform) { false }
             end
 
-            it "removes the deployable label" do
-              pull_request.should_receive(:remove_labels)
+            it "does not add any labels" do
+              pull_request.should_not_receive(:add_labels)
             end
           end
 
           context "when the merge to deployable succeeds" do
-            it "doesn't remove the deployable label" do
-              pull_request.should_not_receive(:remove_labels)
+            it "adds a label" do
+              pull_request.should_receive(:add_labels)
             end
           end
 
@@ -134,7 +134,6 @@ module Octopolo
             pull_request.should_receive(:add_labels)
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
What
----------------------
> What are you changing?  Describe impact and scope.

Why
----------------------
> Why is this being changed?  Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA/A-HA/etc links may not be available in the future.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Hop over to https://github.com/sportngin/octopolo/pull/118 and make sure it's in the deployable branch
- [x] Hop over to https://github.com/sportngin/octopolo/pull/119 and make sure it's not in deployable branch
- [x] Try to merge https://github.com/sportngin/octopolo/pull/119 to the deployable branch by running `op deployable` from the branch `test2`
- [x] Verify there is an error when deploying
- [x] Verify https://github.com/sportngin/octopolo/pull/119 still does not have a deployable label