### PR TITLE
Stop stage-up if a Travis build has failed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,8 @@ source 'https://rubygems.org'
 gem 'guard', '~>2.5.0'
 gemspec
 
+  # Using this branch to grab a fix for a bug that we found on Travis. The 
+  # bug's progress is documented here: https://github.com/travis-ci/travis.rb/issues/578
+
+gem 'travis', git: 'https://github.com/textarcana/travis.rb.git', branch: 'fix-issue-578'
+

--- a/lib/octopolo/commands/stage_up.rb
+++ b/lib/octopolo/commands/stage_up.rb
@@ -1,8 +1,12 @@
 arg :pull_request_id
 desc 'Merges PR into the staging branch'
 command 'stage-up' do |c|
+  c.desc "Follow Travis"
+  c.switch :follow_travis, :negatable => false
+  
   c.action do |global_options, options, args|
     require_relative '../scripts/stage_up'
-    Octopolo::Scripts::StageUp.execute args.first
+    options = global_options.merge(options)
+    Octopolo::Scripts::StageUp.execute(args.first, options)
   end
 end

--- a/lib/octopolo/config.rb
+++ b/lib/octopolo/config.rb
@@ -65,6 +65,15 @@ module Octopolo
       end
     end
 
+    # def validations
+    #   case @validations
+    #   when Array, String then Array(@validations)
+    #   when NilClass then []
+    #   else
+    #     raise(InvalidAttributeSupplied, "Validations must be an array or string")
+    #   end
+    # end
+
     def use_pivotal_tracker
       !!@use_pivotal_tracker
     end

--- a/lib/octopolo/config.rb
+++ b/lib/octopolo/config.rb
@@ -65,15 +65,6 @@ module Octopolo
       end
     end
 
-    # def validations
-    #   case @validations
-    #   when Array, String then Array(@validations)
-    #   when NilClass then []
-    #   else
-    #     raise(InvalidAttributeSupplied, "Validations must be an array or string")
-    #   end
-    # end
-
     def use_pivotal_tracker
       !!@use_pivotal_tracker
     end

--- a/lib/octopolo/github.rb
+++ b/lib/octopolo/github.rb
@@ -51,6 +51,11 @@ module Octopolo
       raise BadCredentials, "Your stored credentials were rejected by GitHub. Run `op github-auth` to generate a new token."
     end
 
+    # TODO: this needs fixing, probably won't work right now
+    def self.private_repo?(repo, options)
+      client.repository(repo, options).private
+    end
+
     def self.pull_request *args
       client.pull_request *args
     end

--- a/lib/octopolo/pull_request_merger.rb
+++ b/lib/octopolo/pull_request_merger.rb
@@ -147,6 +147,10 @@ module Octopolo
       # TODO: change log link to check for private/public repository
       puts "To view #{build.state} log, visit: https://travis-ci.org/#{repo_name}/builds/#{build.id}"
 
+      # to write the entire log to stdout:
+      # job  = build.jobs.first
+      # puts job.log.body
+
       return build.state
     end
 

--- a/lib/octopolo/scripts/stage_up.rb
+++ b/lib/octopolo/scripts/stage_up.rb
@@ -1,12 +1,13 @@
 require_relative "../scripts"
 require_relative "../pull_request_merger"
+require "yaml"
 
 module Octopolo
   module Scripts
     class StageUp
       include CLIWrapper
 
-      attr_accessor :pull_request_id, :options
+      attr_accessor :pull_request_id, :options, :travis_config_file
 
       def self.execute(pull_request_id=nil, options)
         new(pull_request_id, options).execute
@@ -19,12 +20,37 @@ module Octopolo
 
       # Public: Perform the script
       def execute
+        if follow_travis?
+          unless config_file_exists?
+            puts "To follow a Travis log, you need to have a ~/.travis.config.yml file set."
+            puts "  To do this, please run: gem install travis && travis login"
+            exit
+          end
+
+          # TODO: check if private/public repo. If private, use https://api.travis-ci.com/ else use ".org"
+          options[:travis_token] = @travis_config_file["endpoints"]["https://api.travis-ci.org/"]["access_token"] if follow_travis?
+        end
+
         if (!self.pull_request_id)
           current = GitHub::PullRequest.current
           self.pull_request_id = current.number if current
         end
         self.pull_request_id ||= cli.prompt("Pull Request ID: ")
-        PullRequestMerger.perform Git::STAGING_PREFIX, Integer(pull_request_id)
+        PullRequestMerger.perform(Git::STAGING_PREFIX, Integer(pull_request_id), @options)
+      end
+
+      def follow_travis?
+        @options[:follow_travis]
+      end
+
+      def config_file_exists?
+        current_dir = Dir.pwd
+        Dir.chdir("/" << current_dir.scan(/Users\/[a-zA-Z]*/).first << "/")
+        if File.exists?(".travis/config.yml")
+          @travis_config_file = YAML::load_file(File.join(Dir.pwd, ".travis/config.yml"))
+          return true
+        end
+        false
       end
     end
   end

--- a/lib/octopolo/scripts/stage_up.rb
+++ b/lib/octopolo/scripts/stage_up.rb
@@ -6,14 +6,15 @@ module Octopolo
     class StageUp
       include CLIWrapper
 
-      attr_accessor :pull_request_id
+      attr_accessor :pull_request_id, :options
 
-      def self.execute(pull_request_id=nil)
-        new(pull_request_id).execute
+      def self.execute(pull_request_id=nil, options)
+        new(pull_request_id, options).execute
       end
 
-      def initialize(pull_request_id=nil)
+      def initialize(pull_request_id=nil, options={})
         @pull_request_id = pull_request_id
+        @options = options
       end
 
       # Public: Perform the script

--- a/lib/octopolo/scripts/tag_release.rb
+++ b/lib/octopolo/scripts/tag_release.rb
@@ -43,6 +43,7 @@ module Octopolo
       def execute
         if should_create_branch?
           update_changelog
+          # TODO: add place to watch travis log
           tag_release
         else
           raise Octopolo::WrongBranch.new("Must perform this script from the deploy branch (#{config.deploy_branch})")

--- a/octopolo.gemspec
+++ b/octopolo.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'pivotal-tracker', '~> 0.5'
   gem.add_dependency 'jiralicious', '~> 0.4'
   gem.add_dependency 'semantic', '~> 1.3'
+  gem.add_dependency 'travis', '~> 1.8.8'
 
   gem.add_development_dependency 'rake', '~> 10.1'
   gem.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
# What and Why
Add a way for users to wait for a Travis log when they run `op stage-up`. If the Travis log is being followed and it fails/errors/is unsuccessfull, then cancel the `op stage-up` command (we don't want to proceed). Because this is the beginning of not merging into master/tagging a release if we know that the Travis build is failing.

Deploy Plan
-----------
Nothing special. Just merge this PR into master and make a new version.

Rollback Plan
-------------
To roll back this change, revert the merge with `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
* https://github.com/travis-ci/travis.rb#ruby-library
* https://github.com/travis-ci/travis.rb/issues/578

QA Plan
-------
- [ ] Run `op stage-up --follow_travis` to watch the Travis logs!