### PR TITLE
Upgrade jiralicious gem to handle the new JIRA API

### DIFF
--- a/lib/octopolo/jira/story_commenter.rb
+++ b/lib/octopolo/jira/story_commenter.rb
@@ -26,7 +26,7 @@ module Octopolo
         begin
           issue.comments.add(comment)
         rescue => e
-          puts "Error: Failed to comment on Jira Issue #{issue_id}" 
+          puts "Error: Failed to comment on Jira Issue. \nException: #{e}"
         end
       end
     end

--- a/lib/octopolo/version.rb
+++ b/lib/octopolo/version.rb
@@ -1,3 +1,3 @@
 module Octopolo
-  VERSION = "1.9.0"
+  VERSION = "1.11.0"
 end

--- a/lib/octopolo/version.rb
+++ b/lib/octopolo/version.rb
@@ -1,3 +1,3 @@
 module Octopolo
-  VERSION = "1.11.0"
+  VERSION = "1.9.0"
 end

--- a/octopolo.gemspec
+++ b/octopolo.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'public_suffix', '~> 2.0' # Lock down to 2.x for Ruby 2.0 compatibility.
   gem.add_dependency 'highline', '~> 1.6'
   gem.add_dependency 'pivotal-tracker', '~> 0.5'
-  gem.add_dependency 'jiralicious', '~> 0.4'
+  gem.add_dependency 'jiralicious', '~> 0.5'
   gem.add_dependency 'semantic', '~> 1.3'
   gem.add_dependency 'nokogiri-happymapper', '~> 0.6.0' # Lock down to 0.6.x for Ruby 2.0 compatibility.
 


### PR DESCRIPTION
What
----------------------
Upgrade the `jiralicious` gem to handle the new JIRA API

Why
----------------------
JIRA has updated the APIs to use an API token for authentication instead of username & password (https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/). In order to use this though, we need to upgrade the version of the `jiralicious` gem to 0.5.0.

Deploy Plan
-----------
Once this change has been made and we deploy to Rubygems, we should update the `.octopolo.yml` configuration file in all repos that use `octopolo` to use the API token for the `jira_password` attribute. The `jira_user` in the config file must be a full email address instead of just a username.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
- [x] Update the repo the `.octopolo.yml` configuration to use an API token for the `jira_password` attribute. Pull this branch for octopolo locally. Run `bundle exec [local/op/bin/octopolo] pull-request` and ensure that you provide a JIRA story id. The command should succeed and add a comment to the JIRA story with a link to your PR.