### PR TITLE
Make expedite's branch form more flexible

### DIFF
--- a/lib/octopolo/commands/pull_request.rb
+++ b/lib/octopolo/commands/pull_request.rb
@@ -3,7 +3,7 @@ command 'pull-request' do |c|
   c.desc "Branch to create the pull request against"
   c.flag [:d, :dest, :destination], :arg_name => "destination_branch", :default_value => Octopolo.config.deploy_branch
 
-  c.desc "Pass -x to skip the prompt and infer from branch. Expects the branch to be in this format: JIRA-123_describe_pr"
+  c.desc "Pass -x to skip the prompt and infer from branch. Expects the branch to be in this format: JIRA-123_describe_pr OR JIRA_123_describe_pr"
   c.switch [:x, :expedite], :arg_name => "expedite"
 
   c.desc "Use $EDITOR to update PR description before creating"

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -70,7 +70,7 @@ module Octopolo
       def check_branch_format
         return if (/.*-\d+_.*/ =~ git.current_branch || /.*_\d+_.*/ =~ git.current_branch )
 
-        cli.say "Branch must match format like 'iss-123_describe_branch' to expedite"
+        cli.say "Branch must match format like 'iss-123_describe_branch' or 'iss_123_describe_branch' to expedite"
         exit 1
       end
       private :check_branch_format

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -72,7 +72,7 @@ module Octopolo
       private :infer_questionnaire
 
       def check_branch_format
-        return if (/.*-\d+_.*/ =~ git.current_branch || /.*_\d+_.*/ =~ git.current_branch)
+        return if (/[a-zA-Z]+-\d+_.*/ =~ git.current_branch || /[a-zA-Z]+_\d+_.*/ =~ git.current_branch)
 
         cli.say "Branch must match format like 'iss-123_describe_branch' or 'iss_123_describe_branch' to expedite"
         exit 1

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -58,14 +58,16 @@ module Octopolo
         check_branch_format
         branch_arr = git.current_branch.split('_')
         issue = branch_arr[0].upcase
-        descr = branch_arr[1..-1].join(' ')
-        title = "#{issue} #{descr}"
+        if issue.include?('-')
+          descr = branch_arr[1..-1].join(' ')
+        else
+          issue = "#{issue}-#{branch_arr[1]}"
+          descr = branch_arr[2..-1].join(' ')
+        end
 
-        self.title = title.include?('-') ? title : title.sub(' ', '-')
-        full_issue = self.title.split(' ').first
-
-        self.pivotal_ids = [full_issue] if config.use_pivotal_tracker
-        self.jira_ids = [full_issue] if config.use_jira
+        self.title = "#{issue} #{descr.capitalize}"
+        self.pivotal_ids = [issue] if config.use_pivotal_tracker
+        self.jira_ids = [issue] if config.use_jira
       end
       private :infer_questionnaire
 

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -70,7 +70,7 @@ module Octopolo
       private :infer_questionnaire
 
       def check_branch_format
-        return if (/.*-\d+_.*/ =~ git.current_branch || /.*_\d+_.*/ =~ git.current_branch )
+        return if (/.*-\d+_.*/ =~ git.current_branch || /.*_\d+_.*/ =~ git.current_branch)
 
         cli.say "Branch must match format like 'iss-123_describe_branch' or 'iss_123_describe_branch' to expedite"
         exit 1

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -59,15 +59,16 @@ module Octopolo
         branch_arr = git.current_branch.split('_')
         issue = branch_arr[0].upcase
         descr = branch_arr[1..-1].join(' ')
+        title = "#{issue} #{descr}"
 
-        self.title = "#{issue} #{descr}"
+        self.title = title.include?('-') ? title : title.sub(' ', '-')
         self.pivotal_ids = [issue] if config.use_pivotal_tracker
         self.jira_ids = [issue] if config.use_jira
       end
       private :infer_questionnaire
 
       def check_branch_format
-        return if /.*-\d+_.*/ =~ git.current_branch
+        return if (/.*-\d+_.*/ =~ git.current_branch || /.*_\d+_.*/ =~ git.current_branch )
 
         cli.say "Branch must match format like 'iss-123_describe_branch' to expedite"
         exit 1

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -29,9 +29,9 @@ module Octopolo
         GitHub.connect do
 
           if options[:expedite]
-            infer_questionaire
+            infer_questionnaire
           else
-            ask_questionaire
+            ask_questionnaire
           end
 
           create_pull_request
@@ -43,7 +43,7 @@ module Octopolo
       end
 
       # Private: Ask questions to create a pull request
-      def ask_questionaire
+      def ask_questionnaire
         alert_reserved_and_exit if git.reserved_branch?
         announce
         ask_title
@@ -51,9 +51,9 @@ module Octopolo
         ask_pivotal_ids if config.use_pivotal_tracker
         ask_jira_ids if config.use_jira
       end
-      private :ask_questionaire
+      private :ask_questionnaire
 
-      def infer_questionaire
+      def infer_questionnaire
         alert_reserved_and_exit if git.reserved_branch?
         check_branch_format
         branch_arr = git.current_branch.split('_')
@@ -64,7 +64,7 @@ module Octopolo
         self.pivotal_ids = [issue] if config.use_pivotal_tracker
         self.jira_ids = [issue] if config.use_jira
       end
-      private :infer_questionaire
+      private :infer_questionnaire
 
       def check_branch_format
         return if /.*-\d+_.*/ =~ git.current_branch

--- a/lib/octopolo/scripts/pull_request.rb
+++ b/lib/octopolo/scripts/pull_request.rb
@@ -62,8 +62,10 @@ module Octopolo
         title = "#{issue} #{descr}"
 
         self.title = title.include?('-') ? title : title.sub(' ', '-')
-        self.pivotal_ids = [issue] if config.use_pivotal_tracker
-        self.jira_ids = [issue] if config.use_jira
+        full_issue = self.title.split(' ').first
+
+        self.pivotal_ids = [full_issue] if config.use_pivotal_tracker
+        self.jira_ids = [full_issue] if config.use_jira
       end
       private :infer_questionnaire
 

--- a/spec/octopolo/scripts/pull_request_spec.rb
+++ b/spec/octopolo/scripts/pull_request_spec.rb
@@ -107,7 +107,7 @@ module Octopolo
           it 'likes the issue-123_blah branch format' do
             subject.send(:infer_questionnaire)
             expect(subject.jira_ids).to eq(['ABC-123'])
-            expect(subject.title).to eq('ABC-123 so fast')
+            expect(subject.title).to eq('ABC-123 So fast')
           end
         end
 
@@ -117,7 +117,7 @@ module Octopolo
           it 'likes the issue-123_blah branch format' do
             subject.send(:infer_questionnaire)
             expect(subject.jira_ids).to eq(['ABC-123'])
-            expect(subject.title).to eq('ABC-123 so fast')
+            expect(subject.title).to eq('ABC-123 So fast')
           end
         end
 

--- a/spec/octopolo/scripts/pull_request_spec.rb
+++ b/spec/octopolo/scripts/pull_request_spec.rb
@@ -101,8 +101,18 @@ module Octopolo
       context "#expedite" do
         subject { PullRequest.new(nil, { expedite: true }) }
 
-        context 'good format' do
+        context 'good format 1' do
           let(:current_branch) { 'abc-123_so_fast'}
+
+          it 'likes the issue-123_blah branch format' do
+            subject.send(:infer_questionaire)
+            expect(subject.jira_ids).to eq(['ABC-123'])
+            expect(subject.title).to eq('ABC-123 so fast')
+          end
+        end
+
+        context 'good format 2' do
+          let(:current_branch) { 'abc_123_so_fast'}
 
           it 'likes the issue-123_blah branch format' do
             subject.send(:infer_questionaire)

--- a/spec/octopolo/scripts/pull_request_spec.rb
+++ b/spec/octopolo/scripts/pull_request_spec.rb
@@ -45,7 +45,7 @@ module Octopolo
       context "#execute" do
         it "if connected to GitHub, asks some questions, creates the pull request, and opens it" do
           GitHub.should_receive(:connect).and_yield
-          expect(subject).to receive(:ask_questionaire)
+          expect(subject).to receive(:ask_questionnaire)
           expect(subject).to receive(:create_pull_request)
           expect(subject).to receive(:update_pivotal)
           expect(subject).to receive(:update_jira)
@@ -61,7 +61,7 @@ module Octopolo
         end
       end
 
-      context "#ask_questionaire" do
+      context "#ask_questionnaire" do
         it "asks appropriate questions to create a pull request" do
           expect(subject).to receive(:announce)
           expect(subject).to receive(:ask_title)
@@ -69,7 +69,7 @@ module Octopolo
           expect(subject).to receive(:ask_jira_ids)
           expect(subject).to receive(:ask_labels)
 
-          subject.send(:ask_questionaire)
+          subject.send(:ask_questionnaire)
         end
 
         context "when checking for staging branch" do
@@ -85,7 +85,7 @@ module Octopolo
 
             subject.should_receive(:alert_reserved_and_exit)
 
-            subject.send(:ask_questionaire)
+            subject.send(:ask_questionnaire)
           end
 
           it "should not ask if the branch is not staging" do
@@ -93,7 +93,7 @@ module Octopolo
 
             subject.should_not_receive(:alert_reserved_and_exit)
 
-            subject.send(:ask_questionaire)
+            subject.send(:ask_questionnaire)
           end
         end
       end
@@ -105,7 +105,7 @@ module Octopolo
           let(:current_branch) { 'abc-123_so_fast'}
 
           it 'likes the issue-123_blah branch format' do
-            subject.send(:infer_questionaire)
+            subject.send(:infer_questionnaire)
             expect(subject.jira_ids).to eq(['ABC-123'])
             expect(subject.title).to eq('ABC-123 so fast')
           end
@@ -115,7 +115,7 @@ module Octopolo
           let(:current_branch) { 'abc_123_so_fast'}
 
           it 'likes the issue-123_blah branch format' do
-            subject.send(:infer_questionaire)
+            subject.send(:infer_questionnaire)
             expect(subject.jira_ids).to eq(['ABC-123'])
             expect(subject.title).to eq('ABC-123 so fast')
           end
@@ -127,7 +127,7 @@ module Octopolo
           it 'does not like other branch format' do
             subject.git.stub(:reserved_branch?).and_return false
             cli.should_receive(:say)
-            expect { subject.send(:infer_questionaire) }.to raise_error(SystemExit)
+            expect { subject.send(:infer_questionnaire) }.to raise_error(SystemExit)
           end
         end
 
@@ -135,7 +135,7 @@ module Octopolo
           subject.git.stub(:reserved_branch?).and_return true
           subject.should_receive(:alert_reserved_and_exit).and_call_original
           cli.should_receive(:say)
-          expect { subject.send(:infer_questionaire) }.to raise_error(SystemExit)
+          expect { subject.send(:infer_questionnaire) }.to raise_error(SystemExit)
         end
       end
 


### PR DESCRIPTION
What
----------------------
Make `expedite`'s branch form more flexible. So take `iss-123_describe_branch`, but also accept `iss_123_describe_branch` as well.

Why
----------------------
Because with all underscores is the form that _I_ use, so I want to be able to use expedite with my branches.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Checkout this branch of octopolo
- [x] Make a branch with the form `iss_123_describe_branch` in another directory
  ```
  git checkout -b iss_123_describe_branch
  git pull origin iss_123_describe_branch
  git commit --allow-empty -m "Empty commit"
  git push
  ```
- [x] Go back to the source branch (this branch)
- [x] Also make a branch with the form `iss-123_describe_branch` in the same directory
  ```
  git checkout -b iss-123_describe_branch
  git pull origin iss-123_describe_branch
  git commit --allow-empty -m "Empty commit"
  git push
  ```
- [x] Run `bundle exec bin/op pull-request -x` with _both_ branches you made
- [x] Verify two new pull requests were made with the proper titles