### PR TITLE
Fix bug where op tag-release on repo with no releases breaks

### DIFF
--- a/lib/octopolo/semver_tag_scrubber.rb
+++ b/lib/octopolo/semver_tag_scrubber.rb
@@ -12,9 +12,17 @@ module Octopolo
     private
 
     def self.scrub_via_regexp(tag, regexp)
-      result = tag.match(regexp)[0]
-      tag.gsub!(regexp, '')
-      result
+      begin
+        result = tag.match(regexp)[0]
+        tag.gsub!(regexp, '')
+        result
+      rescue Exception => e
+        if e.message.include?("match' for nil:NilClass")
+          puts 'You are creating the first GitHub release for this repository.'
+        else
+          puts "Error finding existing GitHub release(s): #{e.message}"
+        end
+      end
     end
 
   end

--- a/spec/octopolo/semver_tag_scrubber_spec.rb
+++ b/spec/octopolo/semver_tag_scrubber_spec.rb
@@ -27,5 +27,21 @@ module Octopolo
       end
     end
 
+    describe 'scrub_via_regexp' do
+      let(:regexp) { /[a-z]*\z/i }
+      let(:tag) { '0.1.1' }
+
+      it 'should return a string' do
+        expect(SemverTagScrubber.scrub_via_regexp(tag, regexp)).to be_a(String)
+      end
+
+      it 'should not raise an error if the tag does not exist' do
+        expect{ SemverTagScrubber.scrub_via_regexp(nil, regexp) }.not_to raise_error(NoMethodError)
+      end
+
+      it 'should return nil if there was no tag' do
+        expect(SemverTagScrubber.scrub_via_regexp(nil, regexp)).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
What
----------------------
See https://github.com/sportngin/octopolo/issues/129 for more information. Just simply rescue that error, and then `op tag-release` continues how a user would expect.

Why
----------------------
This will fix https://github.com/sportngin/octopolo/issues/129.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run `GLI_DEBUG=true ../octopolo/bin/op tag-release` on a repository with no releases (for SE folk, I made https://github.com/sportngin/test-emma-release/releases to test with), and watch it succeed